### PR TITLE
Add prompt management page

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from src.ui.navigation import render_sidebar
 from src.ui.task_list import render_active_tasks, render_completed_tasks, render_deleted_tasks
 from src.ui.task_form import render_task_form
 from src.ui.ai_chat import render_ai_chat
+from src.ui.prompt_management import render_prompt_management
 
 st.set_page_config(
     page_title="Task Management System",
@@ -75,6 +76,9 @@ def main():
         def ai_assistant_page():
             render_ai_chat()
 
+        def prompt_management_page():
+            render_prompt_management()
+
         def debug_page():
             st.header("Debug Information: Session State")
             # Convert session state to a readable format
@@ -94,10 +98,11 @@ def main():
         completed_page = st.Page(completed_tasks_page, title="Completed Tasks", icon="✨")
         deleted_page = st.Page(deleted_tasks_page, title="Deleted Tasks", icon="🗑️")
         ai_page = st.Page(ai_assistant_page, title="AI Assistant", icon="🤖")
+        prompt_page = st.Page(prompt_management_page, title="Prompt Management", icon="📝")
         debug_page_nav = st.Page(debug_page, title="Debug", icon="🐞")
         
         # Create navigation
-        page = st.navigation([active_page, completed_page, deleted_page, ai_page, debug_page_nav])
+        page = st.navigation([active_page, completed_page, deleted_page, ai_page, prompt_page, debug_page_nav])
         
         # Run the selected page
         page.run()

--- a/pages/prompt_management.py
+++ b/pages/prompt_management.py
@@ -1,0 +1,10 @@
+"""Prompt Management page for AI prompts."""
+import streamlit as st
+from src.ui.prompt_management import render_prompt_management
+
+def main():
+    st.title("Prompt Management")
+    render_prompt_management()
+
+if __name__ == "__main__":
+    main()

--- a/src/ai/prompt_service.py
+++ b/src/ai/prompt_service.py
@@ -1,0 +1,22 @@
+import logging
+from typing import List, Dict, Any
+from src.ai.prompt_repository import prompt_repository
+from src.database.models import AIPrompt
+
+logger = logging.getLogger(__name__)
+
+class PromptService:
+    """Service layer for prompt operations."""
+
+    def __init__(self):
+        self.repository = prompt_repository
+
+    def get_all_prompts(self) -> List[AIPrompt]:
+        logger.info("Getting all prompts")
+        return self.repository.get_all_prompts()
+
+    def update_prompt(self, prompt_id: str, prompt_data: Dict[str, Any]) -> bool:
+        logger.info(f"Updating prompt {prompt_id}")
+        return self.repository.update_prompt(prompt_id, prompt_data)
+
+prompt_service = PromptService()

--- a/src/ui/prompt_management.py
+++ b/src/ui/prompt_management.py
@@ -1,0 +1,45 @@
+"""UI components for managing AI prompts."""
+import streamlit as st
+from src.ai.prompt_service import prompt_service
+from src.database.models import PromptStatus
+
+
+def render_prompt_management():
+    """Render prompt management interface."""
+    st.header("Prompt Management")
+
+    try:
+        prompts = prompt_service.get_all_prompts()
+    except Exception as e:
+        st.error(f"Error loading prompts: {e}")
+        return
+
+    if not prompts:
+        st.info("No prompts found.")
+        return
+
+    for prompt in prompts:
+        with st.expander(prompt.prompt_name, expanded=False):
+            with st.form(key=f"prompt_form_{prompt.id}"):
+                text = st.text_area("Prompt Text", value=prompt.text, key=f"text_{prompt.id}")
+                status = st.selectbox(
+                    "Status",
+                    options=[PromptStatus.ACTIVE, PromptStatus.INACTIVE],
+                    index=0 if prompt.status == PromptStatus.ACTIVE else 1,
+                    key=f"status_{prompt.id}"
+                )
+                submit = st.form_submit_button("Update")
+
+            if submit:
+                if not text.strip():
+                    st.error("Prompt text cannot be empty")
+                else:
+                    data = {"text": text, "status": status}
+                    try:
+                        if prompt_service.update_prompt(prompt.id, data):
+                            st.success("Prompt updated successfully!")
+                            st.rerun()
+                        else:
+                            st.error("Failed to update prompt")
+                    except Exception as e:
+                        st.error(f"Failed to update prompt: {e}")


### PR DESCRIPTION
## Summary
- add PromptService for working with Firestore AI prompts
- create UI to view and edit prompts
- wire new Prompt Management page into navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_683f471328cc8332a52ce7f357dd794e