### PR TITLE
Add summary page

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,7 @@ from src.ui.task_list import render_active_tasks, render_completed_tasks, render
 from src.ui.task_form import render_task_form
 from src.ui.ai_chat import render_ai_chat
 from src.ui.prompt_management import render_prompt_management
+from src.ui.summary import render_summary
 
 st.set_page_config(
     page_title="Task Management System",
@@ -81,6 +82,9 @@ def main():
         def prompt_management_page():
             render_prompt_management()
 
+        def summary_page():
+            render_summary()
+
         def debug_page():
             st.header("Debug Information: Session State")
             # Convert session state to a readable format
@@ -101,10 +105,19 @@ def main():
         deleted_page = st.Page(deleted_tasks_page, title="Deleted Tasks", icon="🗑️")
         ai_page = st.Page(ai_assistant_page, title="AI Assistant", icon="🤖")
         prompt_page = st.Page(prompt_management_page, title="Prompt Management", icon="📝")
+        summary_nav = st.Page(summary_page, title="Summary", icon="📋")
         debug_page_nav = st.Page(debug_page, title="Debug", icon="🐞")
         
         # Create navigation
-        page = st.navigation([active_page, completed_page, deleted_page, ai_page, prompt_page, debug_page_nav])
+        page = st.navigation([
+            active_page,
+            completed_page,
+            deleted_page,
+            ai_page,
+            prompt_page,
+            summary_nav,
+            debug_page_nav,
+        ])
         
         # Run the selected page
         page.run()

--- a/pages/summary.py
+++ b/pages/summary.py
@@ -1,0 +1,10 @@
+"""Summary page for weekly task updates."""
+import streamlit as st
+from src.ui.summary import render_summary
+
+def main():
+    st.title("Summary")
+    render_summary()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- show weekly summary of task updates
- include new summary page in navigation
- use OpenAI to summarize recent updates into short bullet points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fc7ecda7c8332a4b337cf3b981818