### PR TITLE
Fix _add_task and add unit tests

### DIFF
--- a/src/ai/openai_service.py
+++ b/src/ai/openai_service.py
@@ -102,13 +102,13 @@ class OpenAIService:
             task_data = json.loads(task_data_str)
             if "title" not in task_data:
                 return {"error": "Task title is required"}
-            task_id = task_service.create_task(
-                user_id=user_id,
-                title=task_data.get("title"),
-                description=task_data.get("description", ""),
-                notes=task_data.get("notes", ""),
-                due_date=task_data.get("due_date")
-            )
+            task_dict = {
+                "title": task_data.get("title"),
+                "description": task_data.get("description", ""),
+                "notes": task_data.get("notes", ""),
+                "due_date": task_data.get("due_date"),
+            }
+            task_id = task_service.create_task(user_id, task_dict)
             return {"success": True, "task_id": task_id}
         except Exception as e:
             logger.error(f"Error adding task: {str(e)}")

--- a/tests/test_openai_add_task.py
+++ b/tests/test_openai_add_task.py
@@ -1,0 +1,43 @@
+import os
+import json
+import sys
+from pathlib import Path
+
+# ensure src is on path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from ai.openai_service import OpenAIService
+
+# helper to create service with fake API key
+
+def create_service():
+    os.environ.setdefault('OPENAI_API_KEY', 'test-key')
+    return OpenAIService()
+
+def test_add_task_valid(monkeypatch):
+    service = create_service()
+    captured = {}
+
+    def mock_create_task(user_id, task_data):
+        captured['user_id'] = user_id
+        captured['task_data'] = task_data
+        return 'task123'
+
+    monkeypatch.setattr('src.ai.openai_service.task_service.create_task', mock_create_task)
+
+    payload = {
+        'title': 'New Task',
+        'description': 'Do something',
+        'notes': 'details',
+        'due_date': '2024-01-01'
+    }
+    result = service._add_task('user1', json.dumps(payload))
+    assert result == {'success': True, 'task_id': 'task123'}
+    assert captured['user_id'] == 'user1'
+    assert captured['task_data'] == payload
+
+def test_add_task_invalid(monkeypatch):
+    service = create_service()
+
+    result = service._add_task('user1', json.dumps({'description': 'no title'}))
+    assert result['error'] == 'Task title is required'


### PR DESCRIPTION
## Summary
- fix `_add_task` to build task dict then call `task_service.create_task`
- add unit tests for `_add_task` covering valid and invalid inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400aa563ac833285d4f15811b0408e