### PR TITLE
Fix task creation call

### DIFF
--- a/src/ai/openai_service.py
+++ b/src/ai/openai_service.py
@@ -102,13 +102,7 @@ class OpenAIService:
             task_data = json.loads(task_data_str)
             if "title" not in task_data:
                 return {"error": "Task title is required"}
-            task_id = task_service.create_task(
-                user_id=user_id,
-                title=task_data.get("title"),
-                description=task_data.get("description", ""),
-                notes=task_data.get("notes", ""),
-                due_date=task_data.get("due_date")
-            )
+            task_id = task_service.create_task(user_id, task_data)
             return {"success": True, "task_id": task_id}
         except Exception as e:
             logger.error(f"Error adding task: {str(e)}")


### PR DESCRIPTION
## Summary
- remove individual keyword args in `_add_task`
- call `task_service.create_task(user_id, task_data)`

## Testing
- `pip install -q streamlit firebase-admin google-auth google-auth-oauthlib langchain langchain-openai langchain_community openai python-dotenv PyJWT git+https://github.com/amit-sw/aiclub_google_auth.git`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400e24d2d48332aea8c4b16e30fa8e