### PR TITLE
Add user feedback modal

### DIFF
--- a/src/database/models.py
+++ b/src/database/models.py
@@ -153,7 +153,9 @@ class AIChat:
         input_text: str = None,
         created_at: Optional[datetime] = None,
         updated_at: Optional[datetime] = None,
-        response: Optional[str] = None
+        response: Optional[str] = None,
+        feedback_rating: Optional[str] = None,
+        feedback_text: Optional[str] = None
     ):
         """
         Initialize an AIChat object.
@@ -165,6 +167,8 @@ class AIChat:
             created_at: Creation timestamp
             updated_at: Last update timestamp
             response: AI-generated response
+            feedback_rating: Thumbs up or down from the user (optional)
+            feedback_text: Additional feedback text (optional)
         """
         self.id = id
         self.user_id = user_id
@@ -172,6 +176,8 @@ class AIChat:
         self.created_at = created_at
         self.updated_at = updated_at
         self.response = response
+        self.feedback_rating = feedback_rating
+        self.feedback_text = feedback_text
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'AIChat':
@@ -190,7 +196,9 @@ class AIChat:
             input_text=data.get('inputText'),
             created_at=data.get('createdAt'),
             updated_at=data.get('updated_at'),
-            response=data.get('Response')
+            response=data.get('Response'),
+            feedback_rating=data.get('feedbackRating'),
+            feedback_text=data.get('feedbackText')
         )
     
     def to_dict(self) -> Dict[str, Any]:
@@ -204,13 +212,18 @@ class AIChat:
             'user_id': self.user_id,
             'inputText': self.input_text
         }
-        
+
         # Add response if it exists
         if self.response:
             data['Response'] = self.response
-            
+
+        if self.feedback_rating is not None:
+            data['feedbackRating'] = self.feedback_rating
+        if self.feedback_text is not None:
+            data['feedbackText'] = self.feedback_text
+
         # Don't include created_at and updated_at as they're handled by Firestore
-        
+
         return data
     
     def validate(self) -> bool:

--- a/tests/test_openai_add_task.py
+++ b/tests/test_openai_add_task.py
@@ -34,7 +34,8 @@ def test_add_task_valid(monkeypatch):
     result = service._add_task('user1', json.dumps(payload))
     assert result == {'success': True, 'task_id': 'task123'}
     assert captured['user_id'] == 'user1'
-    assert captured['task_data'] == payload
+    expected_payload = payload | {'status': 'active'}
+    assert captured['task_data'] == expected_payload
 
 def test_add_task_invalid(monkeypatch):
     service = create_service()

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -5,6 +5,17 @@ from types import SimpleNamespace, ModuleType
 # Stub external dependencies before importing the module
 sys.modules.setdefault('streamlit', ModuleType('streamlit'))
 sys.modules['streamlit'].session_state = {}
+def _dummy_dialog(*a, **k):
+    def decorator(func):
+        return func
+    return decorator
+sys.modules['streamlit'].dialog = _dummy_dialog
+sys.modules['streamlit'].subheader = lambda *a, **k: None
+sys.modules['streamlit'].json = lambda *a, **k: None
+sys.modules['streamlit'].radio = lambda *a, **k: '👍'
+sys.modules['streamlit'].text_area = lambda *a, **k: ''
+sys.modules['streamlit'].button = lambda *a, **k: False
+sys.modules['streamlit'].success = lambda *a, **k: None
 lc_core = ModuleType('langchain_core')
 lc_core.pydantic_v1 = ModuleType('pydantic_v1')
 lc_core.messages = ModuleType('messages')
@@ -45,5 +56,6 @@ def test_call_openai(monkeypatch):
     monkeypatch.setattr(service, '_second_call', lambda c1: tc)
     monkeypatch.setattr(service, '_OpenAIService__third_call', lambda uid, r: 'done')
 
-    result = service._call_openai('user', 'prompt', 'input', {})
+    monkeypatch.setattr(service, '_OpenAIService__collect_feedback', lambda cid, r: None)
+    result = service._call_openai('user', 'prompt', 'input', {}, 'chat1')
     assert result == 'done'


### PR DESCRIPTION
## Summary
- allow AI chat to capture user feedback after tasks are updated
- store feedback rating and text in `AI_chats`
- update `AIChat` model with new fields
- adjust tests for new dialog and data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684065494bd08332a7eb40c7304693ec