### PR TITLE
Fix feedback modal flow

### DIFF
--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -16,6 +16,7 @@ sys.modules['streamlit'].radio = lambda *a, **k: '👍'
 sys.modules['streamlit'].text_area = lambda *a, **k: ''
 sys.modules['streamlit'].button = lambda *a, **k: False
 sys.modules['streamlit'].success = lambda *a, **k: None
+sys.modules['streamlit'].stop = lambda: None
 lc_core = ModuleType('langchain_core')
 lc_core.pydantic_v1 = ModuleType('pydantic_v1')
 lc_core.messages = ModuleType('messages')


### PR DESCRIPTION
## Summary
- update AI dialog handling with a blocking form
- persist intermediate OpenAI responses until feedback is given
- call OpenAI processing while `ai_processing` state is active
- update test stubs for new Streamlit usage

## Testing
- `pip install firebase-admin jwt langchain-core langchain-openai`
- `pip install google-auth-oauthlib`
- `pip uninstall -y jwt`
- `pip install --force-reinstall PyJWT==2.10.1`
- `export PYTHONPATH=$(pwd)/src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406cd8bd588332a0c296375eafc053