### PR TITLE
Add CI workflow and test documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test Suite
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest -v

--- a/README.md
+++ b/README.md
@@ -89,14 +89,18 @@ For detailed information, refer to the documentation folder:
 ## Running Tests
 
 Unit tests are located in the `tests/` directory. To run the full
-test suite, execute:
+test suite locally, install the required dependencies and execute:
 
 ```bash
+pip install -r requirements.txt
 pytest
 ```
 
-This requires the development dependencies listed in
-`requirements.txt`.
+The repository also provides automated test execution using
+[GitHub Actions](https://github.com/features/actions). Every push and
+pull request triggers the workflow defined in
+`.github/workflows/test.yml`, which installs the dependencies and runs
+`pytest` in a clean environment.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run the test suite
- document local test execution and CI in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f98f5ff08332aab83a65ac3c2398