### PR TITLE
Fix get_all_tasks_for_user method

### DIFF
--- a/src/tasks/task_repository.py
+++ b/src/tasks/task_repository.py
@@ -19,11 +19,22 @@ class TaskRepository:
         self.db = firestore_client
 
     def get_all_tasks(self) -> List[Task]:
+        """Return all tasks for all users."""
         try:
             tasks_data = self.db.query(self.collection, order_by='updatedAt', direction='DESCENDING')
             return [Task.from_dict(task_data) for task_data in tasks_data]
         except Exception as e:
             logger.error(f"Error getting all tasks: {str(e)}")
+            raise
+
+    def get_all_tasks_for_user(self, user_id: str) -> List[Task]:
+        """Return all tasks belonging to the given user."""
+        try:
+            filters = [('userId', '==', user_id)]
+            tasks_data = self.db.query(self.collection, filters=filters, order_by='updatedAt', direction='DESCENDING')
+            return [Task.from_dict(task_data) for task_data in tasks_data]
+        except Exception as e:
+            logger.error(f"Error getting all tasks for user {user_id}: {str(e)}")
             raise
     
     def get_active_tasks(self, user_id: str) -> List[Task]:

--- a/src/tasks/task_service.py
+++ b/src/tasks/task_service.py
@@ -17,9 +17,10 @@ class TaskService:
         """Initialize task service with task repository."""
         self.repository = task_repository
 
-    def get_all_tasks(self, user_id: str) -> List[Task]:
+    def get_all_tasks_for_user(self, user_id: str) -> List[Task]:
+        """Return all tasks belonging to the given user."""
         logger.info(f"Getting all tasks for user {user_id}")
-        return self.repository.get_all_tasks(user_id)
+        return self.repository.get_all_tasks_for_user(user_id)
     
     def get_active_tasks(self, user_id: str) -> List[Task]:
         """

--- a/src/ui/summary.py
+++ b/src/ui/summary.py
@@ -17,7 +17,7 @@ def render_summary():
     """Render a summary of task updates from the last week."""
     st.header("Weekly Summary")
     user_id = st.session_state.user.get('email')
-    tasks = task_service.get_all_tasks(user_id)
+    tasks = task_service.get_all_tasks_for_user(user_id)
     one_week_ago = datetime.now(datetime.utcnow().astimezone().tzinfo) - timedelta(days=7)
     recent_updates = []
 

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -47,3 +47,11 @@ def test_delete_restore_complete(monkeypatch):
     repo.restore_task.assert_called_once_with('u1', 't1')
     service.complete_task('u1', 't1')
     repo.complete_task.assert_called_once_with('u1', 't1')
+
+
+def test_get_all_tasks_for_user(monkeypatch):
+    service, repo = _setup_service(monkeypatch)
+    repo.get_all_tasks_for_user.return_value = ['task1']
+    result = service.get_all_tasks_for_user('u1')
+    assert result == ['task1']
+    repo.get_all_tasks_for_user.assert_called_once_with('u1')


### PR DESCRIPTION
## Summary
- rename TaskService's user task retrieval method to `get_all_tasks_for_user`
- implement `get_all_tasks_for_user` in `TaskRepository`
- update summary page and tests
- add unit test for new method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840fba0b5bc833284bb4e71a8825f70