### PR TITLE
Lazy init Firestore client

### DIFF
--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,4 +1,4 @@
 """AI module for the Task Management System."""
 
 # Expose modules for easier imports
-from src.ai.prompt_repository import prompt_repository
+from src.ai.prompt_repository import get_prompt_repository

--- a/src/ai/prompt_repository.py
+++ b/src/ai/prompt_repository.py
@@ -5,7 +5,7 @@ Handles data access operations for AI prompts in Firestore.
 import logging
 from typing import Dict, List, Optional, Any
 
-from src.database.firestore import firestore_client
+from src.database.firestore import get_client
 from src.database.models import AIPrompt, PromptStatus
 
 # Configure logging
@@ -17,7 +17,7 @@ class PromptRepository:
     def __init__(self):
         """Initialize prompt repository with Firestore client."""
         self.collection = 'AI_prompts'
-        self.db = firestore_client
+        self.db = get_client()
     
     def get_active_prompt(self, prompt_name: str) -> Optional[AIPrompt]:
         """
@@ -128,5 +128,12 @@ class PromptRepository:
             logger.error(f"Error deleting prompt {prompt_id}: {str(e)}")
             raise
 
-# Create an instance for use in the application
-prompt_repository = PromptRepository()
+_prompt_repository: Optional[PromptRepository] = None
+
+
+def get_prompt_repository() -> PromptRepository:
+    """Return the PromptRepository singleton."""
+    global _prompt_repository
+    if _prompt_repository is None:
+        _prompt_repository = PromptRepository()
+    return _prompt_repository

--- a/src/ai/prompt_service.py
+++ b/src/ai/prompt_service.py
@@ -1,6 +1,6 @@
 import logging
-from typing import List, Dict, Any
-from src.ai.prompt_repository import prompt_repository
+from typing import List, Dict, Any, Optional
+from src.ai.prompt_repository import get_prompt_repository
 from src.database.models import AIPrompt
 
 logger = logging.getLogger(__name__)
@@ -9,7 +9,7 @@ class PromptService:
     """Service layer for prompt operations."""
 
     def __init__(self):
-        self.repository = prompt_repository
+        self.repository = get_prompt_repository()
 
     def get_all_prompts(self) -> List[AIPrompt]:
         logger.info("Getting all prompts")
@@ -19,4 +19,12 @@ class PromptService:
         logger.info(f"Updating prompt {prompt_id}")
         return self.repository.update_prompt(prompt_id, prompt_data)
 
-prompt_service = PromptService()
+_prompt_service: Optional[PromptService] = None
+
+
+def get_prompt_service() -> PromptService:
+    """Return the PromptService singleton."""
+    global _prompt_service
+    if _prompt_service is None:
+        _prompt_service = PromptService()
+    return _prompt_service

--- a/src/database/firestore.py
+++ b/src/database/firestore.py
@@ -368,5 +368,13 @@ class FirestoreClient:
         
         return log_data
 
-# Create a singleton instance
-firestore_client = FirestoreClient()
+_firestore_client: Optional[FirestoreClient] = None
+
+
+def get_client() -> FirestoreClient:
+    """Return the Firestore client singleton, creating it if necessary."""
+    global _firestore_client
+    if _firestore_client is None:
+        _firestore_client = FirestoreClient()
+    return _firestore_client
+

--- a/src/tasks/task_repository.py
+++ b/src/tasks/task_repository.py
@@ -5,7 +5,7 @@ Handles data access operations for tasks in Firestore.
 import logging
 from datetime import datetime
 from typing import Dict, List, Optional, Any
-from src.database.firestore import firestore_client
+from src.database.firestore import get_client
 from src.database.models import Task, TaskStatus
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ class TaskRepository:
     def __init__(self):
         """Initialize task repository with Firestore client."""
         self.collection = 'tasks'
-        self.db = firestore_client
+        self.db = get_client()
 
     def get_all_tasks(self) -> List[Task]:
         try:
@@ -269,4 +269,12 @@ class TaskRepository:
         except Exception as e:
             logger.error(f"Error completing task {task_id}: {str(e)}")
             raise
-task_repository = TaskRepository()
+_task_repository: Optional[TaskRepository] = None
+
+
+def get_task_repository() -> TaskRepository:
+    """Return the TaskRepository singleton."""
+    global _task_repository
+    if _task_repository is None:
+        _task_repository = TaskRepository()
+    return _task_repository

--- a/src/tasks/task_service.py
+++ b/src/tasks/task_service.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Optional, Any
 from src.database.models import Task, TaskStatus
-from src.tasks.task_repository import task_repository
+from src.tasks.task_repository import get_task_repository
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ class TaskService:
     
     def __init__(self):
         """Initialize task service with task repository."""
-        self.repository = task_repository
+        self.repository = get_task_repository()
 
     def get_all_tasks(self, user_id: str) -> List[Task]:
         logger.info(f"Getting all tasks for user {user_id}")
@@ -178,5 +178,12 @@ class TaskService:
         logger.info(f"Completing task {task_id} for user {user_id}")
         return self.repository.complete_task(user_id, task_id)
 
-# Create an instance for use in the application
-task_service = TaskService()
+_task_service: Optional[TaskService] = None
+
+
+def get_task_service() -> TaskService:
+    """Return the TaskService singleton."""
+    global _task_service
+    if _task_service is None:
+        _task_service = TaskService()
+    return _task_service

--- a/src/ui/ai_chat.py
+++ b/src/ui/ai_chat.py
@@ -5,9 +5,9 @@ Handles rendering of AI chat interface and interactions.
 import streamlit as st
 import logging
 from typing import Dict, Any
-from src.ai.openai_service import openai_service, TaskChanges
+from src.ai.openai_service import get_openai_service, TaskChanges
 import traceback
-from src.database.firestore import firestore_client
+from src.database.firestore import get_client
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ def __collect_feedback(chat_id: str, resp: TaskChanges) -> bool:
         if submit:
             logger.info(f"Feedback submitted for chat_id {chat_id}")
             st.session_state[feedback_key] = True
-            firestore_client.update(
+            get_client().update(
                 'AI_chats',
                 chat_id,
                 {"feedbackRating": rating, "feedbackText": text},
@@ -81,7 +81,7 @@ def render_ai_chat():
             ai_input_with_id = st.session_state.get(
                 "ai_input_with_id", f"{st.session_state.ai_input}\n\nuser_id: {user_id}"
             )
-            result = openai_service.process_chat(user_id, ai_input_with_id)
+            result = get_openai_service().process_chat(user_id, ai_input_with_id)
             logger.info(f"\n\n\nAI response: {result}")
             if result:
                 st.session_state.ai_response = result.get("response")

--- a/src/ui/prompt_management.py
+++ b/src/ui/prompt_management.py
@@ -1,6 +1,6 @@
 """UI components for managing AI prompts."""
 import streamlit as st
-from src.ai.prompt_service import prompt_service
+from src.ai.prompt_service import get_prompt_service
 from src.database.models import PromptStatus
 
 
@@ -9,7 +9,7 @@ def render_prompt_management():
     st.header("Prompt Management")
 
     try:
-        prompts = prompt_service.get_all_prompts()
+        prompts = get_prompt_service().get_all_prompts()
     except Exception as e:
         st.error(f"Error loading prompts: {e}")
         return
@@ -29,7 +29,7 @@ def render_prompt_management():
             else:
                 data = {"text": text}
                 try:
-                    if prompt_service.update_prompt(prompt.id, data):
+                    if get_prompt_service().update_prompt(prompt.id, data):
                         st.success("Prompt updated successfully!")
                         st.rerun()
                     else:

--- a/src/ui/summary.py
+++ b/src/ui/summary.py
@@ -10,14 +10,14 @@ import streamlit as st
 from langchain_community.chat_models import ChatOpenAI
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from src.tasks.task_service import task_service
+from src.tasks.task_service import get_task_service
 
 
 def render_summary():
     """Render a summary of task updates from the last week."""
     st.header("Weekly Summary")
     user_id = st.session_state.user.get('email')
-    tasks = task_service.get_all_tasks(user_id)
+    tasks = get_task_service().get_all_tasks(user_id)
     one_week_ago = datetime.now(datetime.utcnow().astimezone().tzinfo) - timedelta(days=7)
     recent_updates = []
 

--- a/src/ui/task_list.py
+++ b/src/ui/task_list.py
@@ -6,7 +6,7 @@ import streamlit as st
 from datetime import datetime
 from typing import List, Callable
 from src.database.models import Task, TaskStatus
-from src.tasks.task_service import task_service
+from src.tasks.task_service import get_task_service
 
 def render_task_list(tasks: List[Task], status: str, on_refresh: Callable = None):
     """
@@ -106,7 +106,7 @@ def render_task_list(tasks: List[Task], status: str, on_refresh: Callable = None
             if status == TaskStatus.ACTIVE:
                 action_buttons = action_col.columns(3)
                 if action_buttons[0].button("✓", key=f"complete_{task.id}", help="Mark as completed"):
-                    if task_service.complete_task(user_id, task.id):
+                    if get_task_service().complete_task(user_id, task.id):
                         st.success("Task marked as completed!")
                         if on_refresh:
                             on_refresh()
@@ -116,7 +116,7 @@ def render_task_list(tasks: List[Task], status: str, on_refresh: Callable = None
                     st.session_state.editing_task = task
                     st.rerun()
                 if action_buttons[2].button("🗑", key=f"delete_{task.id}", help="Delete task"):
-                    if task_service.delete_task(user_id, task.id):
+                    if get_task_service().delete_task(user_id, task.id):
                         st.success("Task deleted!")
                         if on_refresh:
                             on_refresh()
@@ -125,7 +125,7 @@ def render_task_list(tasks: List[Task], status: str, on_refresh: Callable = None
             
             elif status == TaskStatus.COMPLETED:
                 if action_col.button("🗑", key=f"delete_{task.id}", help="Delete task"):
-                    if task_service.delete_task(user_id, task.id):
+                    if get_task_service().delete_task(user_id, task.id):
                         st.success("Task deleted!")
                         if on_refresh:
                             on_refresh()
@@ -133,7 +133,7 @@ def render_task_list(tasks: List[Task], status: str, on_refresh: Callable = None
                         st.error("Failed to delete task.")
             elif status == TaskStatus.DELETED:
                 if action_col.button("↩", key=f"restore_{task.id}", help="Restore task"):
-                    if task_service.restore_task(user_id, task.id):
+                    if get_task_service().restore_task(user_id, task.id):
                         st.success("Task restored!")
                         if on_refresh:
                             on_refresh()
@@ -190,7 +190,7 @@ def render_active_tasks():
         st.session_state.adding_task = True
         st.rerun()
     user_id = st.session_state.user.get('email')
-    tasks = task_service.get_active_tasks(user_id)
+    tasks = get_task_service().get_active_tasks(user_id)
     def refresh_tasks():
         st.session_state.refresh_active = True
         st.rerun()
@@ -200,7 +200,7 @@ def render_completed_tasks():
     """Render completed tasks list with refresh capability."""
     st.header("Completed Tasks")
     user_id = st.session_state.user.get('email')
-    tasks = task_service.get_completed_tasks(user_id)
+    tasks = get_task_service().get_completed_tasks(user_id)
     def refresh_tasks():
         st.session_state.refresh_completed = True
         st.rerun()
@@ -210,7 +210,7 @@ def render_deleted_tasks():
     """Render deleted tasks list with refresh capability."""
     st.header("Deleted Tasks")
     user_id = st.session_state.user.get('email')
-    tasks = task_service.get_deleted_tasks(user_id)
+    tasks = get_task_service().get_deleted_tasks(user_id)
     def refresh_tasks():
         st.session_state.refresh_deleted = True
         st.rerun()

--- a/tests/test_firestore_logging.py
+++ b/tests/test_firestore_logging.py
@@ -5,7 +5,7 @@ from datetime import datetime
 # ensure src is on path
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
 
-from database.firestore import firestore_client
+from database.firestore import FirestoreClient
 from firebase_admin.firestore import SERVER_TIMESTAMP
 
 
@@ -25,7 +25,8 @@ def test_prepare_data_for_logging():
         'custom': CustomObject()
     }
 
-    result = firestore_client._prepare_data_for_logging(data)
+    fc = FirestoreClient.__new__(FirestoreClient)
+    result = fc._prepare_data_for_logging(data)
 
     assert result['timestamp'] == '2024-01-01T12:00:00'
     assert result['server_ts'] == '<SERVER_TIMESTAMP>'

--- a/tests/test_openai_add_task.py
+++ b/tests/test_openai_add_task.py
@@ -2,6 +2,7 @@ import os
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 # ensure src is on path
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
@@ -10,20 +11,22 @@ from ai.openai_service import OpenAIService
 
 # helper to create service with fake API key
 
-def create_service():
+def create_service(monkeypatch):
     os.environ.setdefault('OPENAI_API_KEY', 'test-key')
+    monkeypatch.setattr('ai.openai_service.get_client', lambda: SimpleNamespace())
     return OpenAIService()
 
 def test_add_task_valid(monkeypatch):
-    service = create_service()
+    service = create_service(monkeypatch)
     captured = {}
 
-    def mock_create_task(user_id, task_data):
-        captured['user_id'] = user_id
-        captured['task_data'] = task_data
-        return 'task123'
+    class DummyTS:
+        def create_task(self, user_id, task_data):
+            captured['user_id'] = user_id
+            captured['task_data'] = task_data
+            return 'task123'
 
-    monkeypatch.setattr('src.ai.openai_service.task_service.create_task', mock_create_task)
+    monkeypatch.setattr('ai.openai_service.get_task_service', lambda: DummyTS())
 
     payload = {
         'title': 'New Task',
@@ -38,7 +41,7 @@ def test_add_task_valid(monkeypatch):
     assert captured['task_data'] == expected_payload
 
 def test_add_task_invalid(monkeypatch):
-    service = create_service()
+    service = create_service(monkeypatch)
 
     result = service._add_task('user1', json.dumps({'description': 'no title'}))
     assert result['error'] == 'Task title is required'

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -49,7 +49,13 @@ from ai.openai_service import OpenAIService, TaskChanges
 
 def test_call_openai(monkeypatch):
     monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
-    monkeypatch.setattr('ai.openai_service.firestore_client', SimpleNamespace())
+    monkeypatch.setattr('ai.openai_service.get_client', lambda: SimpleNamespace())
+    dummy_ts = SimpleNamespace(
+        get_active_tasks=lambda uid: [],
+        get_completed_tasks=lambda uid: [],
+        get_deleted_tasks=lambda uid: []
+    )
+    monkeypatch.setattr('ai.openai_service.get_task_service', lambda: dummy_ts)
     service = OpenAIService()
 
     monkeypatch.setattr(service, '_first_call', lambda sp, ui, tl: 'content')

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -9,7 +9,7 @@ from tasks.task_service import TaskService
 
 def _setup_service(monkeypatch):
     mock_repo = MagicMock()
-    monkeypatch.setattr('tasks.task_service.task_repository', mock_repo)
+    monkeypatch.setattr('tasks.task_service.get_task_repository', lambda: mock_repo)
     service = TaskService()
     return service, mock_repo
 


### PR DESCRIPTION
## Summary
- create `get_client` in firestore module for lazy singleton init
- update all modules to call `get_client` instead of using a global
- provide accessor helpers for task and prompt services/repositories
- adapt UI modules and services to the new accessors
- fix tests to mock the client and services lazily

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840fb9e16cc8332a1a3f44f9777bd1d