### PR TITLE
Add details buttons on eval candidates page

### DIFF
--- a/src/ui/eval_candidates.py
+++ b/src/ui/eval_candidates.py
@@ -24,19 +24,33 @@ def render_eval_candidates():
         if not chats:
             st.info("No chats found.")
         for chat in chats:
-            cols = st.columns([4, 1])
+            cols = st.columns([4, 1, 1])
             cols[0].markdown(f"**{chat.get('inputText','')}**")
             if cols[1].button("Add to Evals", key=f"add_{chat['id']}"):
                 get_eval_input_service().add_from_chat(chat)
                 st.success("Added to evaluation inputs")
                 st.rerun()
+            if cols[2].button("Details", key=f"chat_details_{chat['id']}"):
+                if 'chat_details' not in st.session_state:
+                    st.session_state.chat_details = {}
+                if chat['id'] in st.session_state.chat_details:
+                    del st.session_state.chat_details[chat['id']]
+                else:
+                    st.session_state.chat_details[chat['id']] = True
+                st.rerun()
+            if (
+                'chat_details' in st.session_state
+                and chat['id'] in st.session_state.chat_details
+            ):
+                with st.expander("Chat Details", expanded=True):
+                    st.json(chat)
 
     with st.expander("Evaluation Inputs", expanded=True):
         eval_inputs = get_eval_input_service().get_latest_inputs(count)
         if not eval_inputs:
             st.info("No evaluation inputs found.")
         for ev in eval_inputs:
-            cols = st.columns([4, 1])
+            cols = st.columns([4, 1, 1])
             cols[0].markdown(f"**{ev.input_text}** - _{ev.status}_")
             toggle = (
                 EvalStatus.ARCHIVED if ev.status == EvalStatus.ACTIVE else EvalStatus.ACTIVE
@@ -44,3 +58,17 @@ def render_eval_candidates():
             if cols[1].button(f"Set {toggle}", key=f"toggle_{ev.id}"):
                 get_eval_input_service().update_status(ev.id, toggle)
                 st.rerun()
+            if cols[2].button("Details", key=f"ev_details_{ev.id}"):
+                if 'eval_details' not in st.session_state:
+                    st.session_state.eval_details = {}
+                if ev.id in st.session_state.eval_details:
+                    del st.session_state.eval_details[ev.id]
+                else:
+                    st.session_state.eval_details[ev.id] = True
+                st.rerun()
+            if (
+                'eval_details' in st.session_state
+                and ev.id in st.session_state.eval_details
+            ):
+                with st.expander("Evaluation Input Details", expanded=True):
+                    st.json(ev.__dict__)


### PR DESCRIPTION
## Summary
- expand columns on Eval Candidates page
- add Details button to show chat info
- add Details button to show evaluation input info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'firebase_admin')*

------
https://chatgpt.com/codex/tasks/task_e_68436cc940ac8332bd3747cd1986e19b