### PR TITLE
Add prompt tracking to AI chats

### DIFF
--- a/documentation/EDD.md
+++ b/documentation/EDD.md
@@ -72,7 +72,9 @@ Document:
   inputText: string,
   createdAt: timestamp,
   updated_at: timestamp,
-  Response: string
+  Response: string,
+  prompt_name: string,
+  prompt_version: number
 }
 ```
 

--- a/documentation/customer_requirements.md
+++ b/documentation/customer_requirements.md
@@ -28,6 +28,8 @@ Each document represents a task with the following fields:
   - `createdAt` (timestamp): When the record was created
   - `updated_at` (timestamp): When the record was last updated (same as createdAt on insert)
   - `Response` (string): AI response from OpenAI (added after processing)
+  - `prompt_name` (string): Name of the prompt used
+  - `prompt_version` (number): Version of the prompt used
 
 ### AI_prompts Collection
 - **Collection Name:** AI_prompts
@@ -48,6 +50,7 @@ Here is the description of the endpoints in a related system that interact with 
 - DELETE /api/tasks/:id: Set `status` to 'deleted', update `updatedAt` (soft-delete).
 - PATCH /api/tasks/:id/restore: Set `status` to 'active', update `updatedAt`.
 - POST /api/ai-chats: Accepts `{ inputText: string }` in request body, requires authentication (JWT), and stores a new document in Firestore `AI_chats` collection with fields: `user_id`, `inputText`, `createdAt`, `updated_at`. After saving, fetches the latest record from Firestore `AI_prompts` where `prompt_name` = "AI_Tasks" and `status` = "Active", uses the `text` field from this prompt as the system prompt for OpenAI (via Langchain), and the user's input as the human prompt. Gets the response from OpenAI, saves it in the same `AI_chats` record as `Response`, and returns it to the frontend.
+- POST /api/ai-chats: Accepts `{ inputText: string }` in request body, requires authentication (JWT), and stores a new document in Firestore `AI_chats` collection with fields: `user_id`, `inputText`, `createdAt`, `updated_at`, `prompt_name`, and `prompt_version`. After saving, fetches the latest record from Firestore `AI_prompts` where `prompt_name` = "AI_Tasks" and `status` = "Active", uses the `text` field from this prompt as the system prompt for OpenAI (via Langchain), and the user's input as the human prompt. Gets the response from OpenAI, saves it in the same `AI_chats` record as `Response`, and returns it to the frontend.
 
 All operations must check that the task's `userId` matches the authenticated user.
 

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -155,7 +155,9 @@ class AIChat:
         updated_at: Optional[datetime] = None,
         response: Optional[str] = None,
         feedback_rating: Optional[str] = None,
-        feedback_text: Optional[str] = None
+        feedback_text: Optional[str] = None,
+        prompt_name: Optional[str] = None,
+        prompt_version: Optional[int] = None
     ):
         """
         Initialize an AIChat object.
@@ -178,6 +180,8 @@ class AIChat:
         self.response = response
         self.feedback_rating = feedback_rating
         self.feedback_text = feedback_text
+        self.prompt_name = prompt_name
+        self.prompt_version = prompt_version
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'AIChat':
@@ -198,7 +202,9 @@ class AIChat:
             updated_at=data.get('updated_at'),
             response=data.get('Response'),
             feedback_rating=data.get('feedbackRating'),
-            feedback_text=data.get('feedbackText')
+            feedback_text=data.get('feedbackText'),
+            prompt_name=data.get('prompt_name'),
+            prompt_version=data.get('prompt_version')
         )
     
     def to_dict(self) -> Dict[str, Any]:
@@ -221,6 +227,10 @@ class AIChat:
             data['feedbackRating'] = self.feedback_rating
         if self.feedback_text is not None:
             data['feedbackText'] = self.feedback_text
+        if self.prompt_name is not None:
+            data['prompt_name'] = self.prompt_name
+        if self.prompt_version is not None:
+            data['prompt_version'] = self.prompt_version
 
         # Don't include created_at and updated_at as they're handled by Firestore
 


### PR DESCRIPTION
## Summary
- extend `AIChat` model with prompt fields
- include prompt name and version when creating chat records
- expose prompt info via OpenAI service
- document new fields in EDD and customer requirements
- test that chat creation records prompt details

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436c4e43288332ac755f6e3d95ce50