### PR TITLE
Add evaluation runner page

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,6 +138,10 @@ def main():
             from src.ui.eval_candidates import render_eval_candidates
             render_eval_candidates()
 
+        def run_evals_page():
+            from src.ui.run_evals import render_run_evals
+            render_run_evals()
+
         def debug_session_state():
             session_items = {}
             for key, value in st.session_state.items():
@@ -220,12 +224,15 @@ def main():
         eval_candidates_nav = st.Page(
             eval_candidates_page, title="Eval Candidates", icon="🧪"
         )
+        run_evals_nav = st.Page(
+            run_evals_page, title="Run Evals", icon="⚙️"
+        )
         debug_page_nav = st.Page(debug_page, title="Debug", icon="🐞")
 
         user_pages = [active_page, completed_page, deleted_page, ai_page]
 
         navigation_pages = [summary_nav, changelog_nav]
-        admin_pages = [prompt_page, eval_candidates_nav, debug_page_nav]
+        admin_pages = [prompt_page, eval_candidates_nav, run_evals_nav, debug_page_nav]
 
         # Create navigation
         # page = st.navigation([

--- a/pages/run_evals.py
+++ b/pages/run_evals.py
@@ -1,0 +1,12 @@
+"""Run evaluations against stored inputs."""
+import streamlit as st
+from src.ui.run_evals import render_run_evals
+
+
+def main():
+    st.title("Run Evals")
+    render_run_evals()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai/eval_result_repository.py
+++ b/src/ai/eval_result_repository.py
@@ -1,0 +1,27 @@
+import logging
+from typing import Dict, Any
+
+from src.database.firestore import get_client
+from src.database.models import AIEvalResult
+
+logger = logging.getLogger(__name__)
+
+class EvalResultRepository:
+    """Repository for AI evaluation results."""
+
+    def __init__(self):
+        self.collection = 'Eval_Results'
+        self.db = get_client()
+
+    def create_result(self, result: AIEvalResult) -> str:
+        data = result.to_dict()
+        return self.db.create(self.collection, data)
+
+_eval_result_repo: EvalResultRepository | None = None
+
+
+def get_eval_result_repository() -> EvalResultRepository:
+    global _eval_result_repo
+    if _eval_result_repo is None:
+        _eval_result_repo = EvalResultRepository()
+    return _eval_result_repo

--- a/src/ai/eval_service.py
+++ b/src/ai/eval_service.py
@@ -1,0 +1,47 @@
+import os
+import logging
+from typing import List, Optional
+
+from langchain_core.messages import SystemMessage, HumanMessage
+from langchain_openai import ChatOpenAI
+
+from src.ai.eval_result_repository import get_eval_result_repository
+from src.ai.prompt_repository import get_prompt_repository
+from src.database.models import AIEvalInput, AIEvalResult
+
+logger = logging.getLogger(__name__)
+
+class EvalService:
+    def __init__(self):
+        self.repo = get_eval_result_repository()
+        self.prompt_repo = get_prompt_repository()
+        self.api_key = os.environ.get('OPENAI_API_KEY')
+        self.model = os.environ.get('OPENAI_MODEL', 'gpt-4.1-mini')
+
+    def run_evals(self, prompt_name: str, version: int, eval_inputs: List[AIEvalInput]) -> List[str]:
+        prompt = self.prompt_repo.get_prompt_by_name_version(prompt_name, version)
+        if not prompt:
+            raise ValueError(f'Prompt {prompt_name} v{version} not found')
+        chat = ChatOpenAI(api_key=self.api_key, model=self.model, temperature=0)
+        result_ids = []
+        for ev in eval_inputs:
+            messages = [SystemMessage(content=prompt.text), HumanMessage(content=ev.input_text)]
+            response = chat.invoke(messages)
+            result = AIEvalResult(
+                eval_input_id=ev.id,
+                prompt_name=prompt_name,
+                prompt_version=version,
+                result=getattr(response, 'content', str(response)),
+            )
+            res_id = self.repo.create_result(result)
+            result_ids.append(res_id)
+        return result_ids
+
+_eval_service: Optional[EvalService] = None
+
+
+def get_eval_service() -> EvalService:
+    global _eval_service
+    if _eval_service is None:
+        _eval_service = EvalService()
+    return _eval_service

--- a/src/ai/prompt_repository.py
+++ b/src/ai/prompt_repository.py
@@ -70,6 +70,38 @@ class PromptRepository:
         except Exception as e:
             logger.error(f"Error getting latest prompts: {str(e)}")
             raise
+
+    def get_all_prompts(self) -> List[AIPrompt]:
+        """Return all prompts, all versions."""
+        try:
+            prompts_data = self.db.query(
+                self.collection,
+                order_by='prompt_name',
+                direction='ASCENDING'
+            )
+            return [AIPrompt.from_dict(d) for d in prompts_data]
+        except Exception as e:
+            logger.error(f"Error getting all prompts: {str(e)}")
+            raise
+
+    def get_prompt_by_name_version(self, name: str, version: int) -> Optional[AIPrompt]:
+        """Return a specific prompt version by name and version."""
+        try:
+            filters = [
+                ('prompt_name', '==', name),
+                ('version', '==', version)
+            ]
+            data = self.db.query(
+                self.collection,
+                filters=filters,
+                limit=1
+            )
+            if not data:
+                return None
+            return AIPrompt.from_dict(data[0])
+        except Exception as e:
+            logger.error(f"Error getting prompt {name} v{version}: {str(e)}")
+            raise
     
     def create_prompt(self, prompt: AIPrompt) -> str:
         """

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -392,3 +392,42 @@ class AIEvalInput:
         if self.status not in [s.value for s in EvalStatus]:
             raise ValueError(f'Invalid status: {self.status}')
         return True
+class AIEvalResult:
+    """Evaluation result for a given input and prompt."""
+
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        eval_input_id: str | None = None,
+        prompt_name: str | None = None,
+        prompt_version: int | None = None,
+        result: str | None = None,
+        created_at: Optional[datetime] = None,
+    ):
+        self.id = id
+        self.eval_input_id = eval_input_id
+        self.prompt_name = prompt_name
+        self.prompt_version = prompt_version
+        self.result = result
+        self.created_at = created_at
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AIEvalResult":
+        return cls(
+            id=data.get("id"),
+            eval_input_id=data.get("eval_input_id"),
+            prompt_name=data.get("prompt_name"),
+            prompt_version=data.get("prompt_version"),
+            result=data.get("result"),
+            created_at=data.get("createdAt"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "eval_input_id": self.eval_input_id,
+            "prompt_name": self.prompt_name,
+            "prompt_version": self.prompt_version,
+            "result": self.result,
+        }
+        return data
+

--- a/src/ui/run_evals.py
+++ b/src/ui/run_evals.py
@@ -1,0 +1,38 @@
+"""UI for running evaluations on stored inputs."""
+
+import streamlit as st
+
+from src.ai.eval_input_service import get_eval_input_service
+from src.ai.eval_service import get_eval_service
+from src.ai.prompt_repository import get_prompt_repository
+from src.database.models import EvalStatus
+
+
+def render_run_evals():
+    st.header("Run Evals")
+
+    eval_inputs = get_eval_input_service().get_latest_inputs(100)
+    active_inputs = [ev for ev in eval_inputs if ev.status == EvalStatus.ACTIVE]
+
+    with st.expander("Evaluation Inputs", expanded=True):
+        if not active_inputs:
+            st.info("No evaluation inputs found.")
+        for ev in active_inputs:
+            st.markdown(f"- {ev.input_text}")
+
+    repo = get_prompt_repository()
+    prompts = repo.get_all_prompts()
+    if not prompts:
+        st.info("No prompts available.")
+        return
+
+    names = sorted({p.prompt_name for p in prompts})
+    prompt_name = st.selectbox("Prompt Name", names)
+    versions = sorted(
+        [p.version for p in prompts if p.prompt_name == prompt_name], reverse=True
+    )
+    prompt_version = st.selectbox("Prompt Version", versions)
+
+    if st.button("Run Evaluations"):
+        get_eval_service().run_evals(prompt_name, int(prompt_version), active_inputs)
+        st.success("Evaluations completed")


### PR DESCRIPTION
## Summary
- support storing evaluation results in new `Eval_Results` collection
- add utilities to fetch specific prompt versions
- implement evaluation service
- add page and UI to run evals with selected prompt
- expose new navigation item in the app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437dc9f5d8833283dcb051e9c347e9