### PR TITLE
Add prompt version management features

### DIFF
--- a/src/ai/prompt_service.py
+++ b/src/ai/prompt_service.py
@@ -12,13 +12,19 @@ class PromptService:
         self.repository = get_prompt_repository()
 
     def get_all_prompts(self) -> List[AIPrompt]:
-        logger.info("Getting latest prompts")
-        return self.repository.get_latest_prompts()
+        """Return all prompts, all versions."""
+        logger.info("Getting all prompts")
+        return self.repository.get_all_prompts()
 
     def update_prompt(self, prompt_id: str, prompt_data: Dict[str, Any]) -> bool:
         logger.info(f"Creating new version for prompt {prompt_id}")
         self.repository.create_prompt_version(prompt_id, prompt_data)
         return True
+
+    def set_active_version(self, prompt_name: str, version: int) -> bool:
+        """Set a specific version of a prompt as the only active version."""
+        logger.info(f"Setting {prompt_name} v{version} as active")
+        return self.repository.set_active_version(prompt_name, version)
 
 _prompt_service: Optional[PromptService] = None
 

--- a/tests/test_prompt_service.py
+++ b/tests/test_prompt_service.py
@@ -16,10 +16,10 @@ def _setup(monkeypatch):
 
 def test_get_all_prompts(monkeypatch):
     service, repo = _setup(monkeypatch)
-    repo.get_latest_prompts.return_value = ['p']
+    repo.get_all_prompts.return_value = ['p']
     result = service.get_all_prompts()
     assert result == ['p']
-    repo.get_latest_prompts.assert_called_once()
+    repo.get_all_prompts.assert_called_once()
 
 
 def test_update_prompt_creates_new_version(monkeypatch):
@@ -28,4 +28,12 @@ def test_update_prompt_creates_new_version(monkeypatch):
     result = service.update_prompt('id1', {'text': 'new text'})
     assert result is True
     repo.create_prompt_version.assert_called_once_with('id1', {'text': 'new text'})
+
+
+def test_set_active_version(monkeypatch):
+    service, repo = _setup(monkeypatch)
+    repo.set_active_version.return_value = True
+    result = service.set_active_version('p1', 2)
+    assert result is True
+    repo.set_active_version.assert_called_once_with('p1', 2)
 


### PR DESCRIPTION
## Summary
- add 'set_active_version' method to PromptRepository/Service
- show prompt names dropdown and active controls in prompt management page
- create new versions as inactive only
- test new PromptService features

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d5a6be0c833290bcb3026184aa65