### PR TITLE
Implement new prompt management workflow

### DIFF
--- a/src/ai/openai_service.py
+++ b/src/ai/openai_service.py
@@ -103,7 +103,11 @@ class OpenAIService:
             response = self._call_openai(user_id, system_prompt.text, input_text, task_list, chat_id)
             if response is None:
                 return None
-            self.db.update(self.collection, chat_id, {'Response': json.dumps(response.model_dump(), cls=FirestoreEncoder)})
+            self.db.update(
+                self.collection,
+                chat_id,
+                {'Response': json.dumps(getattr(response, 'model_dump', response.dict)(), cls=FirestoreEncoder)},
+            )
             logger.debug(f"Chat processed for user {user_id}")
             return {
                 'chat_id': chat_id,

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -262,7 +262,9 @@ class AIPrompt:
         prompt_name: str = None,
         text: str = None,
         status: str = PromptStatus.ACTIVE,
-        version: int = 1
+        version: int = 1,
+        created_at: Optional[datetime] = None,
+        updated_at: Optional[datetime] = None,
     ):
         """
         Initialize an AIPrompt object.
@@ -278,6 +280,8 @@ class AIPrompt:
         self.text = text
         self.status = status
         self.version = version
+        self.created_at = created_at
+        self.updated_at = updated_at
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'AIPrompt':
@@ -295,7 +299,9 @@ class AIPrompt:
             prompt_name=data.get('prompt_name'),
             text=data.get('text'),
             status=data.get('status', PromptStatus.ACTIVE),
-            version=data.get('version', 1)
+            version=data.get('version', 1),
+            created_at=data.get('createdAt'),
+            updated_at=data.get('updatedAt')
         )
     
     def to_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- extend `AIPrompt` model with `created_at` and `updated_at`
- adjust OpenAI service to accept either `model_dump` or `dict` when saving responses
- redesign prompt management UI with sections for creating new versions and changing active prompt version
- provide dropdown for versions showing creation dates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d810a0ac83328055c3bb4410ded3