### PR TITLE
Update debug view to show all prompts

### DIFF
--- a/app.py
+++ b/app.py
@@ -196,7 +196,8 @@ def main():
                 st.dataframe(df)
             with st.expander("Prompts"):
                 prompt_repository = get_prompt_repository()
-                prompts = prompt_repository.get_latest_prompts()
+                # Display all prompts rather than just the latest versions
+                prompts = prompt_repository.get_all_prompts()
                 prompt_list = [prompt.to_dict() for prompt in prompts]
                 df = pd.DataFrame(prompt_list)
                 st.dataframe(df)


### PR DESCRIPTION
## Summary
- show all prompts in the debug info instead of only latest versions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ddbc2f2c8332b1e3d9107171c783