### PR TITLE
Fix Firestore get_all bug

### DIFF
--- a/src/database/firestore.py
+++ b/src/database/firestore.py
@@ -167,7 +167,13 @@ class FirestoreClient:
     def get_all(self, collection: str):
         try:
             docs = self.db.collection(collection).stream()
-            return [doc.to_dict() for doc in docs]
+            results = []
+            for doc in docs:
+                data = doc.to_dict()
+                if data is not None:
+                    data['id'] = doc.id
+                    results.append(data)
+            return results
         except Exception as e:
             logger.error(f"DB ERROR [GET ALL] - Collection: {collection} - Error: {str(e)}")
             raise

--- a/tests/test_firestore_get_all.py
+++ b/tests/test_firestore_get_all.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from database.firestore import FirestoreClient
+
+class DummyDoc:
+    def __init__(self, doc_id, data):
+        self.id = doc_id
+        self._data = data
+    def to_dict(self):
+        return self._data
+
+class DummyDB:
+    def __init__(self, docs):
+        self._docs = docs
+    def collection(self, _):
+        return self
+    def stream(self):
+        for doc in self._docs:
+            yield doc
+
+def test_get_all_adds_id():
+    docs = [DummyDoc('1', {'a': 1}), DummyDoc('2', {'b': 2})]
+    fc = FirestoreClient.__new__(FirestoreClient)
+    fc.db = DummyDB(docs)
+    result = fc.get_all('c')
+    assert result == [{'a': 1, 'id': '1'}, {'b': 2, 'id': '2'}]


### PR DESCRIPTION
## Summary
- ensure FirestoreClient.get_all returns document ids
- add regression test for get_all

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6844714245388332b4bcf52830f31979