### PR TITLE
Refactor _call_openai in openai_service.py to be its own separate class in its own file.

### DIFF
--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -2,3 +2,4 @@
 
 # Expose modules for easier imports
 from src.ai.prompt_repository import get_prompt_repository
+from src.ai.openai_executor import OpenAIExecutor

--- a/src/ai/openai_executor.py
+++ b/src/ai/openai_executor.py
@@ -1,0 +1,18 @@
+import streamlit as st
+from contextlib import nullcontext
+from typing import Any, Dict
+
+class OpenAIExecutor:
+    def __init__(self, service):
+        self.service = service
+
+    def execute(self, user_id: str, system_prompt: str, user_input: str, task_list: Dict[str, Any], chat_id: str):
+        spinner = getattr(st, "spinner", None)
+        if spinner is None:
+            spinner = nullcontext
+        with spinner("Processing your request..."):
+            content1 = self.service._first_call(system_prompt, user_input, task_list)
+            resp = self.service._second_call(content1)
+            final_response = self.service._OpenAIService__third_call(user_id, resp)
+        return final_response
+


### PR DESCRIPTION
## Summary
- remove `_call_openai` from `OpenAIService`
- add `OpenAIExecutor` class for handling OpenAI calls
- delegate chat processing to `OpenAIExecutor`
- adjust tests for the new executor

## Testing
- `pip install -q -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6844bf22f2e083329f3d62c39bb91a59