### PR TITLE
Refactor chat functions into chat_service

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ if AUTH_TYPE == "auth0":
     from src.auth.auth0_auth import Auth0Auth
 else:
     from aiclub_auth_lib.oauth import AIClubGoogleAuth
-from src.ai.llm_service import delete_all_chats_one_by_one, get_all_chats
+from src.ai.chat_service import delete_all_chats_one_by_one, get_all_chats
 from src.tasks.task_service import get_task_service
 from src.ai.prompt_repository import get_prompt_repository
 import pandas as pd

--- a/app_auth0.py
+++ b/app_auth0.py
@@ -8,7 +8,7 @@ import streamlit as st
 import uuid
 from dotenv import load_dotenv
 from src.auth.auth0_auth import Auth0Auth
-from src.ai.llm_service import delete_all_chats_one_by_one, get_all_chats
+from src.ai.chat_service import delete_all_chats_one_by_one, get_all_chats
 from src.tasks.task_service import get_task_service
 from src.ai.prompt_repository import get_prompt_repository
 import pandas as pd

--- a/src/ai/chat_service.py
+++ b/src/ai/chat_service.py
@@ -1,0 +1,33 @@
+import logging
+
+from src.database.firestore import get_client
+
+logger = logging.getLogger(__name__)
+
+
+def delete_all_chats_one_by_one(n: int):
+    try:
+        client = get_client()
+        source = 'AI_chats'
+        archive = 'AI_chats_archive'
+        docs = client.db.collection(source).stream()
+        count = 0
+        for doc in docs:
+            data = doc.to_dict()
+            client.db.collection(archive).document(doc.id).set(data)
+            doc.reference.delete()
+            count += 1
+            if count >= n:
+                break
+        logger.info(f"Archived and deleted {count} documents from {source}")
+    except Exception as e:
+        logger.error(f"Error archiving and deleting AI chats: {str(e)}")
+        raise
+
+
+def get_all_chats():
+    try:
+        return get_client().get_all('AI_chats')
+    except Exception as e:
+        logger.error(f"Error getting all AI chats: {str(e)}")
+        raise

--- a/src/ai/llm_service.py
+++ b/src/ai/llm_service.py
@@ -6,14 +6,13 @@ import traceback
 from typing import Any, Dict, List, Optional
 
 import streamlit as st
-from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.messages import SystemMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from src.ai.llm_executor import LlmExecutor
 
 from src.tasks.task_service import get_task_service
 from src.database.firestore import get_client
-from src.database.models import AIChat, AIPrompt, PromptStatus
+from src.database.models import AIPrompt, PromptStatus
 from src.ai.prompt_repository import get_prompt_repository
 from pydantic import BaseModel
 
@@ -47,37 +46,6 @@ class TaskChanges(BaseModel):
     new_tasks: List[NewTask]
     modified_tasks: List[ModifiedTask]
 
-def delete_all_chats_one_by_one(n: int):
-    try:
-        client = get_client()
-        source_collection = 'AI_chats'
-        archive_collection = 'AI_chats_archive'
-
-        docs = client.db.collection(source_collection).stream()
-        count = 0
-        for doc in docs:
-            data = doc.to_dict()
-            client.db.collection(archive_collection).document(doc.id).set(data)
-            doc.reference.delete()
-            count += 1
-            if count >= n:
-                break
-
-        logger.info(
-            f"Archived and deleted {count} documents from {source_collection}"
-        )
-    except Exception as e:
-        logger.error(
-            f"Error archiving and deleting AI chats: {str(e)}"
-        )
-        raise
-
-def get_all_chats():
-    try:
-        return get_client().get_all('AI_chats')
-    except Exception as e:
-        logger.error(f"Error getting all AI chats: {str(e)}")
-        raise
 
 
 class LlmService:

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from ai.chat_service import delete_all_chats_one_by_one, get_all_chats
+
+
+class DummyDoc:
+    def __init__(self, doc_id, data, deleted, archive_calls):
+        self.id = doc_id
+        self._data = data
+        self.reference = SimpleNamespace(delete=lambda: deleted.append(doc_id))
+        self._archive_calls = archive_calls
+
+    def to_dict(self):
+        return self._data
+
+
+class DummyCollection:
+    def __init__(self, docs, archive_calls, deleted):
+        self._docs = [DummyDoc(d[0], d[1], deleted, archive_calls) for d in docs]
+        self.archive_calls = archive_calls
+
+    def stream(self):
+        for doc in self._docs:
+            yield doc
+
+    def document(self, doc_id):
+        return SimpleNamespace(set=lambda data: self.archive_calls.append((doc_id, data)))
+
+
+class DummyDB:
+    def __init__(self, docs):
+        self.deleted = []
+        self.archive_calls = []
+        self._source = DummyCollection(docs, self.archive_calls, self.deleted)
+        self.archive = DummyCollection([], self.archive_calls, self.deleted)
+
+    def collection(self, name):
+        if name == 'AI_chats':
+            return self._source
+        return self.archive
+
+
+def test_delete_all_chats(monkeypatch):
+    docs = [('1', {'a': 1}), ('2', {'b': 2}), ('3', {'c': 3})]
+    dummy_db = DummyDB(docs)
+    monkeypatch.setattr('ai.chat_service.get_client', lambda: SimpleNamespace(db=dummy_db))
+    delete_all_chats_one_by_one(2)
+    assert dummy_db.deleted == ['1', '2']
+    assert dummy_db.archive_calls == [('1', {'a': 1}), ('2', {'b': 2})]
+
+
+def test_get_all_chats(monkeypatch):
+    monkeypatch.setattr('ai.chat_service.get_client', lambda: SimpleNamespace(get_all=lambda c: [1, 2, 3]))
+    result = get_all_chats()
+    assert result == [1, 2, 3]


### PR DESCRIPTION
## Summary
- relocate chat-related helpers into a new `chat_service` module
- update imports in app entrypoints
- clean unused imports from llm_service
- add unit tests for chat_service

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6844f0d266408332bdc279a740a86bd0