### PR TITLE
Refactor LLM execution

### DIFF
--- a/src/ai/llm_executor.py
+++ b/src/ai/llm_executor.py
@@ -1,6 +1,16 @@
-import streamlit as st
+import json
+import logging
+import traceback
 from contextlib import nullcontext
 from typing import Any, Dict
+
+import streamlit as st
+from langchain_core.messages import SystemMessage, HumanMessage
+from langchain_openai import ChatOpenAI
+from src.ai.llm_models import FirestoreEncoder, TaskChanges
+from src.tasks.task_service import get_task_service
+
+logger = logging.getLogger(__name__)
 
 class LlmExecutor:
     def __init__(self, service):
@@ -11,8 +21,82 @@ class LlmExecutor:
         if spinner is None:
             spinner = nullcontext
         with spinner("Processing your request..."):
-            content1 = self.service._first_call(system_prompt, user_input, task_list)
-            resp = self.service._second_call(content1)
-            final_response = self.service._LlmService__third_call(user_id, resp)
+            content1 = self._first_call(system_prompt, user_input, task_list)
+            resp = self._second_call(content1)
+            final_response = self.__third_call(user_id, resp)
         return final_response
 
+    def _first_call(self, system_prompt: str, user_input: str, task_list: Dict[str, Any]) -> str:
+        try:
+            chat = ChatOpenAI(
+                api_key=self.service.api_key,
+                model=self.service.model,
+                temperature=0.7
+            )
+            clean_input = user_input.strip()
+            active_tasks_str = json.dumps(task_list.get('active', []), indent=2, cls=FirestoreEncoder)
+            completed_tasks_str = json.dumps(task_list.get('completed', []), indent=2, cls=FirestoreEncoder)
+            full_prompt = f"""{system_prompt}\n\nCurrent active tasks:\n{active_tasks_str}
+            Completed tasks:\n{completed_tasks_str}
+            Based on the user's request, determine what changes need to be made to the task list.
+            List each change separately.
+            """
+            messages = [
+                SystemMessage(content=full_prompt),
+                HumanMessage(content=clean_input)
+            ]
+            logger.debug("\n\n\nCalling OpenAI with structured output schema PYDANTIC-H tool")
+            response = chat.invoke(messages)
+            return response.content
+        except Exception as e:
+            logger.error(f"FIRST CALL:Error calling OpenAI API: {str(e)}")
+            raise
+
+    def _second_call(self, content1: str) -> TaskChanges:
+        logger.debug(f"\n\n\nCalling second-call {content1}")
+        logger.debug(f"Entering _second_call. Received content1:\n{content1}")
+        system_prompt = "You are an AI assistant that processes a list of task descriptions and structures them into new and modified tasks. Strictly adhere to the provided Pydantic model for the output format. Ensure all required fields are present for each task. The input text is a list of proposed changes."
+        try:
+            chat = ChatOpenAI(
+                api_key=self.service.api_key,
+                model=self.service.model,
+                temperature=0.2
+            )
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=content1)
+            ]
+            response = chat.with_structured_output(TaskChanges).invoke(messages)
+            logger.debug(f"Successfully structured output in _second_call: {response}")
+            return response
+        except Exception as e:
+            detailed_error_message = f"Error Type: {type(e).__name__}\n"
+            detailed_error_message += f"Error Args: {e.args}\n"
+            if hasattr(e, 'response') and e.response is not None and hasattr(e.response, 'status_code'):
+                detailed_error_message += f"API Response Status: {e.response.status_code}\n"
+                detailed_error_message += f"API Response Headers: {e.response.headers}\n"
+                try:
+                    detailed_error_message += f"API Response JSON: {e.response.json()}\n"
+                except ValueError:
+                    detailed_error_message += f"API Response Text: {e.response.text}\n"
+            logger.error(f"SECOND CALL: Error calling OpenAI API. Details:\n{detailed_error_message}\nContent1 that caused error (first 500 chars):\n{content1[:500]}\nTraceback:\n{traceback.format_exc()}")
+            raise
+
+    def __third_call(self, user_id: str, resp: TaskChanges) -> TaskChanges:
+        logger.debug(f"\n\n\nCalling third-call {resp}")
+        try:
+            ts = get_task_service()
+            for new_task in resp.new_tasks:
+                task_data = new_task.dict(exclude_none=True)
+                logger.debug(f"Creating task for {user_id}: {task_data}")
+                ts.create_task(user_id, task_data)
+            for mod_task in resp.modified_tasks:
+                task_id = mod_task.id
+                raw_data = mod_task.dict(exclude={'id'})
+                update_data = {k: v for k, v in raw_data.items() if v is not None}
+                logger.debug(f"Updating task {task_id} for {user_id} with {update_data}")
+                ts.update_task(user_id, task_id, update_data)
+            return resp
+        except Exception as e:
+            logger.error(f"THIRD CALL: Error updating tasks - {str(e)}")
+            return None

--- a/src/ai/llm_models.py
+++ b/src/ai/llm_models.py
@@ -1,0 +1,30 @@
+import json
+from typing import List, Optional
+from pydantic import BaseModel
+
+class FirestoreEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if hasattr(obj, 'isoformat'):
+            return obj.isoformat()
+        try:
+            return str(obj)
+        except:
+            return None
+
+class NewTask(BaseModel):
+    title: str
+    description: Optional[str] = None
+    notes: Optional[str] = None
+    due_date: Optional[str] = None
+
+class ModifiedTask(BaseModel):
+    id: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    notes: Optional[str] = None
+    due_date: Optional[str] = None
+    status: Optional[str] = None
+
+class TaskChanges(BaseModel):
+    new_tasks: List[NewTask]
+    modified_tasks: List[ModifiedTask]

--- a/src/ai/llm_service.py
+++ b/src/ai/llm_service.py
@@ -3,48 +3,19 @@ import os
 import json
 import logging
 import traceback
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import streamlit as st
-from langchain_core.messages import SystemMessage, HumanMessage
-from langchain_openai import ChatOpenAI
 from src.ai.llm_executor import LlmExecutor
+from src.ai.llm_models import FirestoreEncoder, TaskChanges
 
 from src.tasks.task_service import get_task_service
 from src.database.firestore import get_client
 from src.database.models import AIPrompt, PromptStatus
 from src.ai.prompt_repository import get_prompt_repository
-from pydantic import BaseModel
 
-class FirestoreEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if hasattr(obj, 'isoformat'):
-            return obj.isoformat()
-        try:
-            return str(obj)
-        except:
-            return None
 
 logger = logging.getLogger(__name__)
-
-class NewTask(BaseModel):
-    title: str
-    description: Optional[str] = None
-    notes: Optional[str] = None
-    due_date: Optional[str] = None
-
-class ModifiedTask(BaseModel):
-    id: str
-    title: Optional[str] = None
-    description: Optional[str] = None
-    notes: Optional[str] = None
-    due_date: Optional[str] = None
-    status: Optional[str] = None
-
-
-class TaskChanges(BaseModel):
-    new_tasks: List[NewTask]
-    modified_tasks: List[ModifiedTask]
 
 
 
@@ -155,89 +126,6 @@ class LlmService:
             logger.error(f"Error getting system prompt: {str(e)}")
         return AIPrompt(prompt_name="AI_Tasks", text=DEFAULT_TEXT, status=PromptStatus.ACTIVE, version=0)
 
-    def _first_call(self, system_prompt: str, user_input: str, task_list: Dict[str, Any]) -> str:
-        try:
-            chat = ChatOpenAI(
-                api_key=self.api_key,
-                model=self.model,
-                temperature=0.7
-            )
-            clean_input = user_input.strip()
-            active_tasks_str = json.dumps(task_list.get('active', []), indent=2, cls=FirestoreEncoder)
-            completed_tasks_str = json.dumps(task_list.get('completed', []), indent=2, cls=FirestoreEncoder)
-            full_prompt = f"""{system_prompt}\n\nCurrent active tasks:\n{active_tasks_str}
-            Completed tasks:\n{completed_tasks_str}
-            Based on the user's request, determine what changes need to be made to the task list.
-            List each change separately.
-            """
-            messages = [
-                SystemMessage(content=full_prompt),
-                HumanMessage(content=clean_input)
-            ]
-            logger.debug(f"\n\n\nCalling OpenAI with structured output schema PYDANTIC-H tool")
-            response = chat.invoke(messages)
-            return response.content
-        except Exception as e:
-            logger.error(f"FIRST CALL:Error calling OpenAI API: {str(e)}")
-            raise
-
-    def _second_call(self, content1: str) -> TaskChanges:
-        logger.debug(f"\n\n\nCalling second-call {content1}")
-        logger.debug(f"Entering _second_call. Received content1:\n{content1}")
-        system_prompt = "You are an AI assistant that processes a list of task descriptions and structures them into new and modified tasks. Strictly adhere to the provided Pydantic model for the output format. Ensure all required fields are present for each task. The input text is a list of proposed changes."
-        try:
-            chat = ChatOpenAI(
-                api_key=self.api_key,
-                model=self.model,
-                temperature=0.2 # Lower temperature for more deterministic structuring
-            )
-            messages = [
-                SystemMessage(content=system_prompt),
-                HumanMessage(content=content1)
-            ]
-            response = chat.with_structured_output(TaskChanges).invoke(messages)
-            logger.debug(f"Successfully structured output in _second_call: {response}")
-            return response
-        except Exception as e:
-            detailed_error_message = f"Error Type: {type(e).__name__}\n"
-            detailed_error_message += f"Error Args: {e.args}\n"
-            # Attempt to get more details if it's an OpenAI/HTTP error
-            if hasattr(e, 'response') and e.response is not None and hasattr(e.response, 'status_code'):
-                detailed_error_message += f"API Response Status: {e.response.status_code}\n"
-                detailed_error_message += f"API Response Headers: {e.response.headers}\n"
-                try:
-                    detailed_error_message += f"API Response JSON: {e.response.json()}\n"
-                except ValueError:
-                    detailed_error_message += f"API Response Text: {e.response.text}\n"
-            
-            logger.error(f"SECOND CALL: Error calling OpenAI API. Details:\n{detailed_error_message}\nContent1 that caused error (first 500 chars):\n{content1[:500]}\nTraceback:\n{traceback.format_exc()}")
-            raise
-
-    def __third_call(self, user_id: str, resp: TaskChanges) -> TaskChanges:
-        """Create and update tasks based on OpenAI response."""
-        logger.debug(f"\n\n\nCalling third-call {resp}")
-        try:
-            # Create new tasks
-            ts = get_task_service()
-            for new_task in resp.new_tasks:
-                task_data = new_task.dict(exclude_none=True)
-                logger.debug(f"Creating task for {user_id}: {task_data}")
-                ts.create_task(user_id, task_data)
-
-            # Update existing tasks
-            for mod_task in resp.modified_tasks:
-                task_id = mod_task.id
-                raw_data = mod_task.dict(exclude={'id'})
-                update_data = {k: v for k, v in raw_data.items() if v is not None}
-                logger.debug(
-                    f"Updating task {task_id} for {user_id} with {update_data}"
-                )
-                ts.update_task(user_id, task_id, update_data)
-
-            return resp
-        except Exception as e:
-            logger.error(f"THIRD CALL: Error updating tasks - {str(e)}")
-            return None
         
 
     def __collect_feedback(self, chat_id: str, resp: TaskChanges) -> bool:

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -46,8 +46,9 @@ root_dir = Path(__file__).resolve().parents[1]
 sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / 'src'))
 
-from ai.llm_service import LlmService, TaskChanges, AIPrompt
+from ai.llm_service import LlmService, AIPrompt
 from ai.llm_executor import LlmExecutor
+from ai.llm_models import TaskChanges
 
 
 def test_call_openai(monkeypatch):
@@ -62,10 +63,10 @@ def test_call_openai(monkeypatch):
     service = LlmService()
     executor = LlmExecutor(service)
 
-    monkeypatch.setattr(service, '_first_call', lambda sp, ui, tl: 'content')
+    monkeypatch.setattr(executor, '_first_call', lambda sp, ui, tl: 'content')
     tc = TaskChanges(new_tasks=[], modified_tasks=[])
-    monkeypatch.setattr(service, '_second_call', lambda c1: tc)
-    monkeypatch.setattr(service, '_LlmService__third_call', lambda uid, r: 'done')
+    monkeypatch.setattr(executor, '_second_call', lambda c1: tc)
+    monkeypatch.setattr(executor, '_LlmExecutor__third_call', lambda uid, r: 'done')
 
     result = executor.execute('user', 'prompt', 'input', {}, 'chat1')
     assert result == 'done'


### PR DESCRIPTION
## Summary
- extract `FirestoreEncoder` and task models into `llm_models`
- move `_first_call`, `_second_call`, and `__third_call` from `llm_service` to `llm_executor`
- update tests for new method locations

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6844f254c6ac83329d2c94130a858492