### PR TITLE
Implement deletion of chat after adding eval input

### DIFF
--- a/src/eval/eval_input_service.py
+++ b/src/eval/eval_input_service.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Any, Optional
 
 from src.eval.eval_input_repository import get_eval_input_repository
 from src.database.models import AIEvalInput, EvalStatus
+from src.database.firestore import get_client
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,11 @@ class EvalInputService:
         return self.repository.get_latest_inputs(count)
 
     def add_from_chat(self, chat_data: Dict[str, Any], eval_prompt: str) -> str:
-        return self.repository.create_from_chat(chat_data, eval_prompt)
+        doc_id = self.repository.create_from_chat(chat_data, eval_prompt)
+        cid = chat_data.get('id')
+        if cid:
+            get_client().delete('AI_chats', cid)
+        return doc_id
 
     def update_status(self, doc_id: str, status: str) -> bool:
         return self.repository.update_status(doc_id, status)

--- a/tests/test_eval_services.py
+++ b/tests/test_eval_services.py
@@ -47,8 +47,10 @@ def _setup_eval_service(monkeypatch):
 
 def _setup_input_service(monkeypatch):
     repo = MagicMock()
+    db = MagicMock()
     monkeypatch.setattr('src.eval.eval_input_service.get_eval_input_repository', lambda: repo)
-    return EvalInputService(), repo
+    monkeypatch.setattr('src.eval.eval_input_service.get_client', lambda: db)
+    return EvalInputService(), repo, db
 
 
 def test_run_evals(monkeypatch):
@@ -68,10 +70,11 @@ def test_run_evals_missing_prompt(monkeypatch):
 
 
 def test_eval_input_service_calls(monkeypatch):
-    service, repo = _setup_input_service(monkeypatch)
+    service, repo, db = _setup_input_service(monkeypatch)
     service.get_latest_inputs(5)
     repo.get_latest_inputs.assert_called_once_with(5)
-    service.add_from_chat({'a': 1}, 'p')
-    repo.create_from_chat.assert_called_once_with({'a': 1}, 'p')
+    service.add_from_chat({'id': 'c1'}, 'p')
+    repo.create_from_chat.assert_called_once_with({'id': 'c1'}, 'p')
+    db.delete.assert_called_once_with('AI_chats', 'c1')
     service.update_status('x', 'archived')
     repo.update_status.assert_called_once_with('x', 'archived')


### PR DESCRIPTION
## Summary
- ensure EvalInputService removes chat after adding it to evaluation inputs
- adjust evaluation service tests to verify deletion

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled)*
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'google.cloud.firestore_v1')*

------
https://chatgpt.com/codex/tasks/task_e_684503c30ad0833284359d99f8e3cdbf