### PR TITLE
Update eval candidates UI and repository

### DIFF
--- a/src/eval/eval_input_repository.py
+++ b/src/eval/eval_input_repository.py
@@ -35,6 +35,9 @@ class EvalInputRepository:
     def update_status(self, doc_id: str, status: str) -> bool:
         return self.db.update(self.collection, doc_id, {'status': status})
 
+    def update_input(self, doc_id: str, data: Dict[str, Any]) -> bool:
+        return self.db.update(self.collection, doc_id, data)
+
 _eval_repo: EvalInputRepository | None = None
 
 

--- a/src/eval/eval_input_service.py
+++ b/src/eval/eval_input_service.py
@@ -24,6 +24,9 @@ class EvalInputService:
     def update_status(self, doc_id: str, status: str) -> bool:
         return self.repository.update_status(doc_id, status)
 
+    def update_input(self, doc_id: str, data: Dict[str, Any]) -> bool:
+        return self.repository.update_input(doc_id, data)
+
 _eval_service: Optional[EvalInputService] = None
 
 

--- a/src/ui/eval_candidates.py
+++ b/src/ui/eval_candidates.py
@@ -1,6 +1,7 @@
 """UI for selecting evaluation candidates from AI chats."""
 
 import streamlit as st
+
 from src.eval.eval_input_service import get_eval_input_service
 from src.database.firestore import get_client
 from src.database.models import EvalStatus
@@ -15,6 +16,69 @@ def _load_ai_chats(count: int):
     )
 
 
+def _render_chat_row(chat):
+    cols = st.columns([4, 2, 1, 1])
+    cols[0].markdown(f"**{chat.get('inputText','')}**")
+    prompt = cols[1].text_input("Prompt", key=f"prompt_{chat['id']}")
+    if cols[2].button("Add to Evals", key=f"add_{chat['id']}"):
+        get_eval_input_service().add_from_chat(chat, prompt)
+        st.success("Added to evaluation inputs")
+        st.rerun()
+    if cols[3].button("Details", key=f"chat_details_{chat['id']}"):
+        if 'chat_details' not in st.session_state:
+            st.session_state.chat_details = {}
+        if chat['id'] in st.session_state.chat_details:
+            del st.session_state.chat_details[chat['id']]
+        else:
+            st.session_state.chat_details[chat['id']] = True
+        st.rerun()
+    if (
+        'chat_details' in st.session_state
+        and chat['id'] in st.session_state.chat_details
+    ):
+        st.subheader("Chat Details")
+        data = {k: v for k, v in chat.items() if k != 'user_id'}
+        st.json(data)
+    st.divider()
+
+
+def _render_eval_row(ev):
+    cols = st.columns([4, 1, 1])
+    cols[0].markdown(f"**{ev.input_text}** - _{ev.status}_")
+    toggle = EvalStatus.ARCHIVED if ev.status == EvalStatus.ACTIVE else EvalStatus.ACTIVE
+    toggle_text = "Archive" if ev.status == EvalStatus.ACTIVE else "Unarchive"
+    if cols[1].button(toggle_text, key=f"toggle_{ev.id}"):
+        get_eval_input_service().update_status(ev.id, toggle)
+        st.rerun()
+    if cols[2].button("Details", key=f"ev_details_{ev.id}"):
+        if 'eval_details' not in st.session_state:
+            st.session_state.eval_details = {}
+        if ev.id in st.session_state.eval_details:
+            del st.session_state.eval_details[ev.id]
+        else:
+            st.session_state.eval_details[ev.id] = True
+        st.rerun()
+    if (
+        'eval_details' in st.session_state
+        and ev.id in st.session_state.eval_details
+    ):
+        with st.form(key=f"edit_{ev.id}"):
+            input_text = st.text_area("Input", value=ev.input_text)
+            response = st.text_area("Response", value=ev.response or "")
+            eval_prompt = st.text_area("Eval Prompt", value=ev.eval_prompt or "")
+            submit = st.form_submit_button("Save")
+        if submit:
+            data = {'inputText': input_text, 'evalPrompt': eval_prompt}
+            if response:
+                data['Response'] = response
+            get_eval_input_service().update_input(ev.id, data)
+            st.success("Updated")
+            st.rerun()
+        data = {k: v for k, v in ev.__dict__.items() if k != 'user_id'}
+        st.json(data)
+    st.divider()
+
+
 def render_eval_candidates():
     st.header("Evaluation Candidates")
     count = int(st.number_input("Count", min_value=1, max_value=100, value=5))
@@ -24,53 +88,11 @@ def render_eval_candidates():
         if not chats:
             st.info("No chats found.")
         for chat in chats:
-            cols = st.columns([4, 2, 1, 1])
-            cols[0].markdown(f"**{chat.get('inputText','')}**")
-            prompt = cols[1].text_input("Prompt", key=f"prompt_{chat['id']}")
-            if cols[2].button("Add to Evals", key=f"add_{chat['id']}"):
-                get_eval_input_service().add_from_chat(chat, prompt)
-                st.success("Added to evaluation inputs")
-                st.rerun()
-            if cols[3].button("Details", key=f"chat_details_{chat['id']}"):
-                if 'chat_details' not in st.session_state:
-                    st.session_state.chat_details = {}
-                if chat['id'] in st.session_state.chat_details:
-                    del st.session_state.chat_details[chat['id']]
-                else:
-                    st.session_state.chat_details[chat['id']] = True
-                st.rerun()
-            if (
-                'chat_details' in st.session_state
-                and chat['id'] in st.session_state.chat_details
-            ):
-                st.subheader("Chat Details")
-                st.json(chat)
+            _render_chat_row(chat)
 
     with st.expander("Evaluation Inputs", expanded=True):
         eval_inputs = get_eval_input_service().get_latest_inputs(count)
         if not eval_inputs:
             st.info("No evaluation inputs found.")
         for ev in eval_inputs:
-            cols = st.columns([4, 1, 1])
-            cols[0].markdown(f"**{ev.input_text}** - _{ev.status}_")
-            toggle = (
-                EvalStatus.ARCHIVED if ev.status == EvalStatus.ACTIVE else EvalStatus.ACTIVE
-            )
-            toggle_text = "Archive" if ev.status == EvalStatus.ACTIVE else "Unarchive"
-            if cols[1].button(toggle_text, key=f"toggle_{ev.id}"):
-                get_eval_input_service().update_status(ev.id, toggle)
-                st.rerun()
-            if cols[2].button("Details", key=f"ev_details_{ev.id}"):
-                if 'eval_details' not in st.session_state:
-                    st.session_state.eval_details = {}
-                if ev.id in st.session_state.eval_details:
-                    del st.session_state.eval_details[ev.id]
-                else:
-                    st.session_state.eval_details[ev.id] = True
-                st.rerun()
-            if (
-                'eval_details' in st.session_state
-                and ev.id in st.session_state.eval_details
-            ):
-                st.subheader("Evaluation Input Details")
-                st.json(ev.__dict__)
+            _render_eval_row(ev)

--- a/tests/test_eval_services.py
+++ b/tests/test_eval_services.py
@@ -78,3 +78,9 @@ def test_eval_input_service_calls(monkeypatch):
     db.delete.assert_called_once_with('AI_chats', 'c1')
     service.update_status('x', 'archived')
     repo.update_status.assert_called_once_with('x', 'archived')
+
+
+def test_eval_input_update(monkeypatch):
+    service, repo, _ = _setup_input_service(monkeypatch)
+    service.update_input('x', {'inputText': 'n'})
+    repo.update_input.assert_called_once_with('x', {'inputText': 'n'})


### PR DESCRIPTION
## Summary
- allow updating evaluation inputs
- remove `user_id` from evaluation pages
- add dividers between candidate rows
- show edit form in evaluation inputs details
- cover new service call in tests

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68452a6be8d88332947eae319b55e11f