### PR TITLE
Implement LLM judge step in eval service

### DIFF
--- a/src/database/models.py
+++ b/src/database/models.py
@@ -413,6 +413,7 @@ class AIEvalResult:
         prompt_name: str | None = None,
         prompt_version: int | None = None,
         result: str | None = None,
+        llm_judge_says: str | None = None,
         created_at: Optional[datetime] = None,
     ):
         self.id = id
@@ -420,6 +421,7 @@ class AIEvalResult:
         self.prompt_name = prompt_name
         self.prompt_version = prompt_version
         self.result = result
+        self.llm_judge_says = llm_judge_says
         self.created_at = created_at
 
     @classmethod
@@ -430,6 +432,7 @@ class AIEvalResult:
             prompt_name=data.get("prompt_name"),
             prompt_version=data.get("prompt_version"),
             result=data.get("result"),
+            llm_judge_says=data.get("LLMJudgeSays"),
             created_at=data.get("createdAt"),
         )
 
@@ -440,5 +443,7 @@ class AIEvalResult:
             "prompt_version": self.prompt_version,
             "result": self.result,
         }
+        if self.llm_judge_says is not None:
+            data["LLMJudgeSays"] = self.llm_judge_says
         return data
 

--- a/src/eval/eval_service.py
+++ b/src/eval/eval_service.py
@@ -27,11 +27,18 @@ class EvalService:
         for ev in eval_inputs:
             messages = [SystemMessage(content=prompt.text), HumanMessage(content=ev.input_text)]
             response = chat.invoke(messages)
+            judge_msgs = [
+                SystemMessage(content="Please evaluate this result as per the criteria provided"),
+                SystemMessage(content=ev.eval_prompt or ""),
+                HumanMessage(content=getattr(response, "content", str(response)))
+            ]
+            judge = chat.invoke(judge_msgs)
             result = AIEvalResult(
                 eval_input_id=ev.id,
                 prompt_name=prompt_name,
                 prompt_version=version,
                 result=getattr(response, 'content', str(response)),
+                llm_judge_says=getattr(judge, 'content', str(judge)),
             )
             res_id = self.repo.create_result(result)
             result_ids.append(res_id)


### PR DESCRIPTION
## Summary
- extend `AIEvalResult` model with `llm_judge_says`
- run an additional LLM call during `run_evals` to judge responses

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68453137f3b08332b5b1407bc91a61b7