### PR TITLE
Add eval data to debug page

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ else:
 from src.ai.chat_service import delete_all_chats_one_by_one, get_all_chats
 from src.tasks.task_service import get_task_service
 from src.ai.prompt_repository import get_prompt_repository
+from src.eval.debug_data import get_eval_inputs, get_eval_results
 import pandas as pd
 
 for key, value in st.secrets.items():
@@ -154,6 +155,14 @@ def main():
             # Display session state as JSON
             st.json(session_items)
 
+        def debug_eval_inputs():
+            df = pd.DataFrame(get_eval_inputs())
+            st.dataframe(df)
+
+        def debug_eval_results():
+            df = pd.DataFrame(get_eval_results())
+            st.dataframe(df)
+
         def debug_page():
             st.header("Debug Information")
             with st.expander("Session State"):
@@ -201,6 +210,10 @@ def main():
                 prompt_list = [prompt.to_dict() for prompt in prompts]
                 df = pd.DataFrame(prompt_list)
                 st.dataframe(df)
+            with st.expander("AI Eval Inputs"):
+                debug_eval_inputs()
+            with st.expander("AI Eval Results"):
+                debug_eval_results()
             with st.expander("Delete AI Chats"):
                 delete_count = st.number_input(
                     "Delete count", min_value=1, max_value=100, value=1

--- a/app_auth0.py
+++ b/app_auth0.py
@@ -11,6 +11,7 @@ from src.auth.auth0_auth import Auth0Auth
 from src.ai.chat_service import delete_all_chats_one_by_one, get_all_chats
 from src.tasks.task_service import get_task_service
 from src.ai.prompt_repository import get_prompt_repository
+from src.eval.debug_data import get_eval_inputs, get_eval_results
 import pandas as pd
 
 load_dotenv()
@@ -117,9 +118,17 @@ def main():
                     session_items[key] = str(value)
                 else:
                     session_items[key] = value
-            
+
             # Display session state as JSON
             st.json(session_items)
+
+        def debug_eval_inputs():
+            df = pd.DataFrame(get_eval_inputs())
+            st.dataframe(df)
+
+        def debug_eval_results():
+            df = pd.DataFrame(get_eval_results())
+            st.dataframe(df)
 
         def debug_page():
             st.header("Debug Information")
@@ -157,6 +166,10 @@ def main():
                 prompt_list=[prompt.to_dict() for prompt in prompts]
                 df=pd.DataFrame(prompt_list)
                 st.dataframe(df)
+            with st.expander("AI Eval Inputs"):
+                debug_eval_inputs()
+            with st.expander("AI Eval Results"):
+                debug_eval_results()
             with st.expander("Delete AI Chats"):
                 if st.button("Delete AI Chats"):
                     delete_all_chats()

--- a/src/eval/debug_data.py
+++ b/src/eval/debug_data.py
@@ -1,0 +1,9 @@
+from src.database.firestore import get_client
+
+
+def get_eval_inputs():
+    return get_client().get_all('AI_Eval_Inputs')
+
+
+def get_eval_results():
+    return get_client().get_all('AI_Eval_Results')

--- a/tests/test_debug_data.py
+++ b/tests/test_debug_data.py
@@ -1,0 +1,21 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from eval.debug_data import get_eval_inputs, get_eval_results
+
+
+def test_get_eval_inputs(monkeypatch):
+    client = SimpleNamespace(get_all=lambda c: ['i'])
+    monkeypatch.setattr('eval.debug_data.get_client', lambda: client)
+    result = get_eval_inputs()
+    assert result == ['i']
+
+
+def test_get_eval_results(monkeypatch):
+    client = SimpleNamespace(get_all=lambda c: ['r'])
+    monkeypatch.setattr('eval.debug_data.get_client', lambda: client)
+    result = get_eval_results()
+    assert result == ['r']


### PR DESCRIPTION
## Summary
- add utility functions to fetch eval inputs and results
- expose eval inputs/results in debug pages
- test debug data utilities

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6845337bbd688332890d38b74475af25