### PR TITLE
Fix Pydantic deprecation warnings

### DIFF
--- a/src/ai/llm_executor.py
+++ b/src/ai/llm_executor.py
@@ -87,12 +87,12 @@ class LlmExecutor:
         try:
             ts = get_task_service()
             for new_task in resp.new_tasks:
-                task_data = new_task.dict(exclude_none=True)
+                task_data = getattr(new_task, 'model_dump', new_task.dict)(exclude_none=True)
                 logger.debug(f"Creating task for {user_id}: {task_data}")
                 ts.create_task(user_id, task_data)
             for mod_task in resp.modified_tasks:
                 task_id = mod_task.id
-                raw_data = mod_task.dict(exclude={'id'})
+                raw_data = getattr(mod_task, 'model_dump', mod_task.dict)(exclude={'id'})
                 update_data = {k: v for k, v in raw_data.items() if v is not None}
                 logger.debug(f"Updating task {task_id} for {user_id} with {update_data}")
                 ts.update_task(user_id, task_id, update_data)

--- a/src/ai/llm_service.py
+++ b/src/ai/llm_service.py
@@ -143,10 +143,10 @@ class LlmService:
         with st.form(f"feedback_form_{chat_id}"):
             st.subheader("New Tasks")
             for t in resp.new_tasks:
-                st.json(t.dict(exclude_none=True))
+                st.json(getattr(t, 'model_dump', t.dict)(exclude_none=True))
             st.subheader("Modified Tasks")
             for t in resp.modified_tasks:
-                st.json(t.dict(exclude_none=True))
+                st.json(getattr(t, 'model_dump', t.dict)(exclude_none=True))
             rating = st.radio(
                 "Are these updates correct?",
                 ("👍", "👎"),

--- a/src/ui/ai_chat.py
+++ b/src/ui/ai_chat.py
@@ -28,10 +28,10 @@ def __collect_feedback(chat_id: str, resp: TaskChanges) -> bool:
     with st.form(f"feedback_form_{chat_id}"):
         st.subheader("New Tasks")
         for t in resp.new_tasks:
-            st.json(t.dict(exclude_none=True))
+            st.json(getattr(t, 'model_dump', t.dict)(exclude_none=True))
         st.subheader("Modified Tasks")
         for t in resp.modified_tasks:
-            st.json(t.dict(exclude_none=True))
+            st.json(getattr(t, 'model_dump', t.dict)(exclude_none=True))
         rating = st.radio(
             "Are these updates correct?",
             ("👍", "👎"),


### PR DESCRIPTION
## Summary
- avoid deprecated Pydantic `.dict` calls
- handle model serialization across AI chat modules

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_684536e118888332a651615a15bf2605