### PR TITLE
Add run-tests menu

### DIFF
--- a/src/ui/navigation.py
+++ b/src/ui/navigation.py
@@ -12,6 +12,7 @@ from src.ai.chat_service import delete_all_chats_one_by_one, get_all_chats
 from src.tasks.task_service import get_task_service
 from src.ai.prompt_repository import get_prompt_repository
 from src.eval.debug_data import get_eval_inputs, get_eval_results
+from src.ui.run_tests import render_run_tests
 logger = logging.getLogger(__name__)
 
 class Page(str, Enum):
@@ -87,6 +88,9 @@ def eval_candidates_page():
 def run_evals_page():
     from src.ui.run_evals import render_run_evals
     render_run_evals()
+
+def run_tests_page():
+    render_run_tests()
 
 def debug_session_state():
     session_items = {}
@@ -164,11 +168,12 @@ def render_main_page():
     prompt_page = st.Page(prompt_management_page, title='Prompt Management', icon='📝')
     summary_nav = st.Page(summary_page, title='Summary', icon='📋')
     changelog_nav = st.Page(changelog_page, title='ChangeLog', icon='📜')
+    run_tests_nav = st.Page(run_tests_page, title='Run Tests', icon='🧪')
     eval_candidates_nav = st.Page(eval_candidates_page, title='Eval Candidates', icon='🧪')
     run_evals_nav = st.Page(run_evals_page, title='Run Evals', icon='⚙️')
     debug_page_nav = st.Page(debug_page, title='Debug', icon='🐞')
     user_pages = [ai_page, active_page, completed_page, deleted_page]
-    navigation_pages = [summary_nav, changelog_nav]
+    navigation_pages = [summary_nav, changelog_nav, run_tests_nav]
     admin_pages = [prompt_page, eval_candidates_nav, run_evals_nav, debug_page_nav]
     page = st.navigation({'============= 🧑\u200d💼 User': user_pages, '============= 🧭 Nav': navigation_pages, '============= 🛠️ Admin': admin_pages})
     page.run()

--- a/src/ui/run_tests.py
+++ b/src/ui/run_tests.py
@@ -1,0 +1,23 @@
+import subprocess
+
+import streamlit as st
+
+
+def render_run_tests():
+    st.header('Run Tests')
+    if st.button('Run Tests with Coverage'):
+        with st.spinner('Running tests...'):
+            result = subprocess.run(
+                ['pytest', '--cov=src', '--cov=tests', '--cov-report=term-missing'],
+                capture_output=True,
+                text=True,
+            )
+        st.session_state.test_output = result.stdout + result.stderr
+        st.session_state.test_returncode = result.returncode
+        st.rerun()
+    if getattr(st.session_state, 'test_output', None) is not None:
+        st.code(st.session_state.test_output)
+        if st.session_state.test_returncode == 0:
+            st.success('Tests passed')
+        else:
+            st.error('Tests failed')

--- a/tests/test_run_tests_page.py
+++ b/tests/test_run_tests_page.py
@@ -1,0 +1,49 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'src'))
+
+st = ModuleType('streamlit')
+class SessionState(dict):
+    def __getattr__(self, name):
+        return self.get(name)
+
+    def __setattr__(self, name, value):
+        self[name] = value
+st.session_state = SessionState()
+output = {}
+
+class Spinner:
+    def __enter__(self):
+        return None
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+st.header = lambda *a, **k: None
+st.button = lambda *a, **k: True
+st.spinner = lambda *a, **k: Spinner()
+st.code = lambda text: output.update({'code': text})
+st.success = lambda *a, **k: output.update({'status': 'success'})
+st.error = lambda *a, **k: output.update({'status': 'error'})
+st.rerun = lambda: None
+sys.modules['streamlit'] = st
+
+import importlib
+import src.ui.run_tests as run_tests
+
+def test_render_run_tests(monkeypatch):
+    st.session_state = SessionState()
+    sys.modules['streamlit'] = st
+    importlib.reload(run_tests)
+    st.button = lambda *a, **k: True
+    st.spinner = lambda *a, **k: Spinner()
+    def fake_run(*a, **k):
+        return SimpleNamespace(stdout='ok', stderr='', returncode=0)
+    monkeypatch.setattr(run_tests.subprocess, 'run', fake_run)
+    run_tests.render_run_tests()
+    assert st.session_state.test_output == 'ok'
+    assert output['status'] == 'success'
+    assert output['code'] == 'ok'


### PR DESCRIPTION
## Summary
- add Run Tests page that executes pytest with coverage
- add new navigation entry under Nav for running tests
- test the new Run Tests page

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6845bd1378a4833291acc294e8eab4bc