### PR TITLE
Add inputText to eval results

### DIFF
--- a/src/database/models.py
+++ b/src/database/models.py
@@ -165,21 +165,24 @@ class AIEvalInput:
 
 class AIEvalResult:
 
-    def __init__(self, id: Optional[str]=None, eval_input_id: str | None=None, prompt_name: str | None=None, prompt_version: int | None=None, result: str | None=None, llm_judge_says: str | None=None, created_at: Optional[datetime]=None):
+    def __init__(self, id: Optional[str]=None, eval_input_id: str | None=None, prompt_name: str | None=None, prompt_version: int | None=None, result: str | None=None, llm_judge_says: str | None=None, input_text: str | None=None, created_at: Optional[datetime]=None):
         self.id = id
         self.eval_input_id = eval_input_id
         self.prompt_name = prompt_name
         self.prompt_version = prompt_version
         self.result = result
         self.llm_judge_says = llm_judge_says
+        self.input_text = input_text
         self.created_at = created_at
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'AIEvalResult':
-        return cls(id=data.get('id'), eval_input_id=data.get('eval_input_id'), prompt_name=data.get('prompt_name'), prompt_version=data.get('prompt_version'), result=data.get('result'), llm_judge_says=data.get('LLMJudgeSays'), created_at=data.get('createdAt'))
+        return cls(id=data.get('id'), eval_input_id=data.get('eval_input_id'), prompt_name=data.get('prompt_name'), prompt_version=data.get('prompt_version'), result=data.get('result'), llm_judge_says=data.get('LLMJudgeSays'), input_text=data.get('inputText'), created_at=data.get('createdAt'))
 
     def to_dict(self) -> Dict[str, Any]:
         data = {'eval_input_id': self.eval_input_id, 'prompt_name': self.prompt_name, 'prompt_version': self.prompt_version, 'result': self.result}
         if self.llm_judge_says is not None:
             data['LLMJudgeSays'] = self.llm_judge_says
+        if self.input_text is not None:
+            data['inputText'] = self.input_text
         return data

--- a/src/eval/eval_service.py
+++ b/src/eval/eval_service.py
@@ -27,7 +27,7 @@ class EvalService:
             response = chat.invoke(messages)
             judge_msgs = [SystemMessage(content='Please evaluate this result as per the criteria provided'), SystemMessage(content=ev.eval_prompt or ''), HumanMessage(content=getattr(response, 'content', str(response)))]
             judge = chat.invoke(judge_msgs)
-            result = AIEvalResult(eval_input_id=ev.id, prompt_name=prompt_name, prompt_version=version, result=getattr(response, 'content', str(response)), llm_judge_says=getattr(judge, 'content', str(judge)))
+            result = AIEvalResult(eval_input_id=ev.id, prompt_name=prompt_name, prompt_version=version, result=getattr(response, 'content', str(response)), llm_judge_says=getattr(judge, 'content', str(judge)), input_text=ev.input_text)
             res_id = self.repo.create_result(result)
             result_ids.append(res_id)
         return result_ids

--- a/tests/test_eval_services.py
+++ b/tests/test_eval_services.py
@@ -56,6 +56,7 @@ def test_run_evals(monkeypatch):
     result = service.run_evals('p', 1, [ev])
     assert result == ['rid']
     repo.create_result.assert_called_once()
+    assert repo.create_result.call_args[0][0].input_text == 'q'
     prepo.get_prompt_by_name_version.assert_called_once_with('p', 1)
 
 def test_run_evals_missing_prompt(monkeypatch):


### PR DESCRIPTION
## Summary
- store `inputText` from `AI_Eval_Inputs` when creating an `Eval_Result`
- test that `EvalService` passes the input text through to the repo

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6846030b3bc083328b16f194b07102f5