### PR TITLE
Implement user role creation at login

### DIFF
--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -13,7 +13,7 @@ def init_session():
         st.session_state.auth_message = ''
 
 def login_user(user_info: Dict[str, Any]):
-    record = get_user_service().login(user_info.get('email'))
+    record = get_user_service().login(user_info.get('email'), user_info.get('name'))
     user_info.update(record)
     st.session_state.user = user_info
     st.session_state.userId = record['userId']

--- a/src/users/user_repository.py
+++ b/src/users/user_repository.py
@@ -13,10 +13,16 @@ class UserRepository:
         records = self.db.query(self.collection, filters=[('userEmail', '==', email)], limit=1)
         return records[0] if records else None
 
-    def create_user(self, email: str, tz: str) -> Dict[str, str]:
-        doc_id = self.db.create(self.collection, {'userEmail': email, 'userTZ': tz})
+    def create_user(self, email: str, tz: str, name: str | None=None) -> Dict[str, str]:
+        data = {'userEmail': email, 'userTZ': tz}
+        if name:
+            data['userName'] = name
+        doc_id = self.db.create(self.collection, data)
         self.db.update(self.collection, doc_id, {'userId': doc_id})
-        return {'userId': doc_id, 'userEmail': email, 'userTZ': tz}
+        record = {'userId': doc_id, 'userEmail': email, 'userTZ': tz}
+        if name:
+            record['userName'] = name
+        return record
 
 _repo: Optional[UserRepository] = None
 

--- a/src/users/user_role_repository.py
+++ b/src/users/user_role_repository.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Optional, Dict
+from src.database.firestore import get_client
+
+logger = logging.getLogger(__name__)
+
+class UserRoleRepository:
+    def __init__(self):
+        self.collection = 'user_roles'
+        self.db = get_client()
+
+    def get_by_user_id(self, user_id: str) -> Optional[Dict[str, str]]:
+        records = self.db.query(self.collection, filters=[('userId', '==', user_id)], limit=1)
+        return records[0] if records else None
+
+    def create_role(self, user_id: str, role: str) -> Dict[str, str]:
+        doc_id = self.db.create(self.collection, {'userId': user_id, 'role': role})
+        return {'id': doc_id, 'userId': user_id, 'role': role}
+
+_repo: Optional[UserRoleRepository] = None
+
+def get_user_role_repository() -> UserRoleRepository:
+    global _repo
+    if _repo is None:
+        _repo = UserRoleRepository()
+    return _repo

--- a/src/users/user_role_service.py
+++ b/src/users/user_role_service.py
@@ -1,0 +1,23 @@
+import logging
+from typing import Dict
+from .user_role_repository import get_user_role_repository
+
+logger = logging.getLogger(__name__)
+
+class UserRoleService:
+    def __init__(self):
+        self.repo = get_user_role_repository()
+
+    def ensure_default_role(self, user_id: str) -> Dict[str, str]:
+        record = self.repo.get_by_user_id(user_id)
+        if record:
+            return record
+        return self.repo.create_role(user_id, 'regular')
+
+_service: UserRoleService | None = None
+
+def get_user_role_service() -> UserRoleService:
+    global _service
+    if _service is None:
+        _service = UserRoleService()
+    return _service

--- a/src/users/user_service.py
+++ b/src/users/user_service.py
@@ -1,18 +1,21 @@
 import logging
 from typing import Dict
 from .user_repository import get_user_repository
+from .user_role_service import get_user_role_service
 
 logger = logging.getLogger(__name__)
 
 class UserService:
     def __init__(self):
         self.repo = get_user_repository()
+        self.role_service = get_user_role_service()
 
-    def login(self, email: str) -> Dict[str, str]:
+    def login(self, email: str, name: str | None=None) -> Dict[str, str]:
         record = self.repo.get_by_email(email)
-        if record:
-            return record
-        return self.repo.create_user(email, 'America/Los_Angeles')
+        if not record:
+            record = self.repo.create_user(email, 'America/Los_Angeles', name)
+        self.role_service.ensure_default_role(record['userId'])
+        return record
 
 _service: UserService | None = None
 

--- a/tests/test_auth0_session.py
+++ b/tests/test_auth0_session.py
@@ -54,15 +54,17 @@ def test_session_login_flow(monkeypatch):
     called = {}
 
     class Dummy:
-        def login(self, email):
+        def login(self, email, name=None):
             called['email'] = email
+            called['name'] = name
             return {'userId': 'u', 'userEmail': email, 'userTZ': 'Z'}
 
     monkeypatch.setattr('src.auth.session.get_user_service', lambda: Dummy())
     init_session()
     assert require_auth() is False
-    login_user({'email': 'e'})
+    login_user({'email': 'e', 'name': 'n'})
     assert called['email'] == 'e'
+    assert called['name'] == 'n'
     assert require_auth() is True
     logout_user()
     assert require_auth() is False


### PR DESCRIPTION
## Summary
- add role repository/service for new `user_roles` table
- store user name when creating user record
- ensure default role on login
- update session login to pass user name
- extend tests for new login behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_6846239a581c83328dcec7cf2d87047f