### PR TITLE
Add Group Management page

### DIFF
--- a/pages/group_management.py
+++ b/pages/group_management.py
@@ -1,0 +1,11 @@
+import streamlit as st
+from src.ui.group_management import render_group_management
+
+
+def main():
+    st.title('Group Management')
+    render_group_management()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/groups/group_repository.py
+++ b/src/groups/group_repository.py
@@ -1,0 +1,27 @@
+import logging
+from typing import Any, Dict, List
+from src.database.firestore import get_client
+
+logger = logging.getLogger(__name__)
+
+class GroupRepository:
+    def __init__(self):
+        self.collection = 'Groups'
+        self.db = get_client()
+
+    def get_groups(self) -> List[Dict[str, Any]]:
+        return self.db.query(self.collection, order_by='createdAt', direction='DESCENDING')
+
+    def create_group(self, data: Dict[str, Any]) -> str:
+        return self.db.create(self.collection, data)
+
+    def update_group(self, group_id: str, data: Dict[str, Any]) -> bool:
+        return self.db.update(self.collection, group_id, data)
+
+_repo: GroupRepository | None = None
+
+def get_group_repository() -> GroupRepository:
+    global _repo
+    if _repo is None:
+        _repo = GroupRepository()
+    return _repo

--- a/src/groups/group_service.py
+++ b/src/groups/group_service.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Any, Dict, List
+from .group_repository import get_group_repository
+
+logger = logging.getLogger(__name__)
+
+class GroupService:
+    def __init__(self):
+        self.repo = get_group_repository()
+
+    def get_groups(self) -> List[Dict[str, Any]]:
+        return self.repo.get_groups()
+
+    def create_group(self, name: str) -> str:
+        return self.repo.create_group({'groupName': name})
+
+    def update_group(self, group_id: str, name: str) -> bool:
+        return self.repo.update_group(group_id, {'groupName': name})
+
+_service: GroupService | None = None
+
+def get_group_service() -> GroupService:
+    global _service
+    if _service is None:
+        _service = GroupService()
+    return _service

--- a/src/groups/user_group_repository.py
+++ b/src/groups/user_group_repository.py
@@ -1,0 +1,27 @@
+import logging
+from typing import Any, Dict, List
+from src.database.firestore import get_client
+
+logger = logging.getLogger(__name__)
+
+class UserGroupRepository:
+    def __init__(self):
+        self.collection = 'UserGroups'
+        self.db = get_client()
+
+    def get_user_groups(self) -> List[Dict[str, Any]]:
+        return self.db.query(self.collection, order_by='createdAt', direction='DESCENDING')
+
+    def create_user_group(self, data: Dict[str, Any]) -> str:
+        return self.db.create(self.collection, data)
+
+    def update_user_group(self, doc_id: str, data: Dict[str, Any]) -> bool:
+        return self.db.update(self.collection, doc_id, data)
+
+_repo: UserGroupRepository | None = None
+
+def get_user_group_repository() -> UserGroupRepository:
+    global _repo
+    if _repo is None:
+        _repo = UserGroupRepository()
+    return _repo

--- a/src/groups/user_group_service.py
+++ b/src/groups/user_group_service.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Any, Dict, List
+from .user_group_repository import get_user_group_repository
+
+logger = logging.getLogger(__name__)
+
+class UserGroupService:
+    def __init__(self):
+        self.repo = get_user_group_repository()
+
+    def get_user_groups(self) -> List[Dict[str, Any]]:
+        return self.repo.get_user_groups()
+
+    def create_user_group(self, data: Dict[str, Any]) -> str:
+        return self.repo.create_user_group(data)
+
+    def update_user_group(self, doc_id: str, data: Dict[str, Any]) -> bool:
+        return self.repo.update_user_group(doc_id, data)
+
+_service: UserGroupService | None = None
+
+def get_user_group_service() -> UserGroupService:
+    global _service
+    if _service is None:
+        _service = UserGroupService()
+    return _service

--- a/src/ui/group_management.py
+++ b/src/ui/group_management.py
@@ -1,0 +1,49 @@
+import streamlit as st
+from src.groups.group_service import get_group_service
+from src.groups.user_group_service import get_user_group_service
+
+
+def _groups_tab():
+    service = get_group_service()
+    groups = service.get_groups()
+    st.dataframe(groups)
+    options = [''] + [g['id'] for g in groups]
+    group_id = st.selectbox('Group', options)
+    name = st.text_input('Group Name')
+    if st.button('Save Group'):
+        if group_id:
+            service.update_group(group_id, name)
+        else:
+            service.create_group(name)
+        st.success('Saved')
+        st.rerun()
+
+
+def _user_groups_tab():
+    service = get_user_group_service()
+    records = service.get_user_groups()
+    st.dataframe(records)
+    options = [''] + [r['id'] for r in records]
+    record_id = st.selectbox('Record', options)
+    group_id = st.text_input('GroupId')
+    group_name = st.text_input('GroupName')
+    user_id = st.text_input('UserId')
+    user_name = st.text_input('UserName')
+    user_email = st.text_input('UserEmail')
+    if st.button('Save UserGroup'):
+        data = {'groupId': group_id, 'groupName': group_name, 'userId': user_id, 'userName': user_name, 'userEmail': user_email}
+        if record_id:
+            service.update_user_group(record_id, data)
+        else:
+            service.create_user_group(data)
+        st.success('Saved')
+        st.rerun()
+
+
+def render_group_management():
+    st.header('Group Management')
+    tabs = st.tabs(['Groups', 'UserGroups'])
+    with tabs[0]:
+        _groups_tab()
+    with tabs[1]:
+        _user_groups_tab()

--- a/src/ui/navigation.py
+++ b/src/ui/navigation.py
@@ -6,6 +6,7 @@ from src.ui.task_list import render_active_tasks, render_completed_tasks, render
 from src.ui.task_form import render_task_form
 from src.ui.ai_chat import render_ai_chat
 from src.ui.prompt_management import render_prompt_management
+from src.ui.group_management import render_group_management
 from src.ui.summary import render_summary
 from src.ui.changelog import render_changelog
 from src.ai.chat_service import delete_all_chats_one_by_one, get_all_chats
@@ -75,6 +76,9 @@ def ai_assistant_page():
 
 def prompt_management_page():
     render_prompt_management()
+
+def group_management_page():
+    render_group_management()
 
 def summary_page():
     render_summary()
@@ -176,6 +180,7 @@ def render_main_page():
     deleted_page = st.Page(deleted_tasks_page, title='Deleted Tasks', icon='🗑️')
     ai_page = st.Page(ai_assistant_page, title='AI Assistant', icon='🤖')
     prompt_page = st.Page(prompt_management_page, title='Prompt Management', icon='📝')
+    group_page = st.Page(group_management_page, title='Group Management', icon='👥')
     summary_nav = st.Page(summary_page, title='Summary', icon='📋')
     changelog_nav = st.Page(changelog_page, title='ChangeLog', icon='📜')
     run_tests_nav = st.Page(run_tests_page, title='Run Tests', icon='🧪')
@@ -184,6 +189,6 @@ def render_main_page():
     debug_page_nav = st.Page(debug_page, title='Debug', icon='🐞')
     user_pages = [ai_page, active_page, completed_page, deleted_page]
     navigation_pages = [summary_nav, changelog_nav, run_tests_nav]
-    admin_pages = [prompt_page, eval_candidates_nav, run_evals_nav, debug_page_nav]
+    admin_pages = [prompt_page, group_page, eval_candidates_nav, run_evals_nav, debug_page_nav]
     page = st.navigation({'============= 🧑\u200d💼 User': user_pages, '============= 🧭 Nav': navigation_pages, '============= 🛠️ Admin': admin_pages})
     page.run()

--- a/tests/test_group_management_ui.py
+++ b/tests/test_group_management_ui.py
@@ -1,0 +1,41 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'src'))
+
+st = ModuleType('streamlit')
+
+class Tab:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+tabs_called = []
+
+def tabs(names):
+    tabs_called.append(names)
+    return [Tab() for _ in names]
+st.tabs = tabs
+st.header = lambda *a, **k: None
+st.dataframe = lambda *a, **k: None
+st.form = lambda *a, **k: SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: None)
+st.selectbox = lambda *a, **k: ''
+st.text_input = lambda *a, **k: ''
+st.form_submit_button = lambda *a, **k: False
+st.success = lambda *a, **k: None
+st.rerun = lambda: None
+sys.modules['streamlit'] = st
+import importlib
+import src.ui.group_management as gm
+importlib.reload(gm)
+
+def test_render_group_management_tabs(monkeypatch):
+    monkeypatch.setattr(gm, 'get_group_service', lambda: SimpleNamespace(get_groups=lambda: []))
+    monkeypatch.setattr(gm, 'get_user_group_service', lambda: SimpleNamespace(get_user_groups=lambda: []))
+    tabs_called.clear()
+    gm.render_group_management()
+    assert tabs_called and tabs_called[0] == ['Groups', 'UserGroups']

--- a/tests/test_group_services.py
+++ b/tests/test_group_services.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+
+from src.groups.group_service import GroupService
+from src.groups.user_group_service import UserGroupService
+
+
+class DummyRepo:
+    def __init__(self):
+        self.calls = []
+
+    def get_groups(self):
+        self.calls.append('get')
+        return []
+
+    def create_group(self, data):
+        self.calls.append(('create', data))
+        return 'id'
+
+    def update_group(self, gid, data):
+        self.calls.append(('update', gid, data))
+        return True
+
+
+class DummyUserGroupRepo:
+    def __init__(self):
+        self.calls = []
+
+    def get_user_groups(self):
+        self.calls.append('get')
+        return []
+
+    def create_user_group(self, data):
+        self.calls.append(('create', data))
+        return 'id'
+
+    def update_user_group(self, uid, data):
+        self.calls.append(('update', uid, data))
+        return True
+
+
+def test_group_service(monkeypatch):
+    repo = DummyRepo()
+    monkeypatch.setattr('src.groups.group_service.get_group_repository', lambda: repo)
+    service = GroupService()
+    service.get_groups()
+    service.create_group('n')
+    service.update_group('g', 'n2')
+    assert repo.calls == ['get', ('create', {'groupName': 'n'}), ('update', 'g', {'groupName': 'n2'})]
+
+
+def test_user_group_service(monkeypatch):
+    repo = DummyUserGroupRepo()
+    monkeypatch.setattr('src.groups.user_group_service.get_user_group_repository', lambda: repo)
+    service = UserGroupService()
+    service.get_user_groups()
+    service.create_user_group({'a': 1})
+    service.update_user_group('u', {'b': 2})
+    assert repo.calls == ['get', ('create', {'a': 1}), ('update', 'u', {'b': 2})]


### PR DESCRIPTION
## Summary
- add group repositories and services
- add Streamlit UI for group management with Groups and UserGroups tabs
- register new admin page in navigation
- test new services and UI

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6846486102b48332bd556ae49be50ca7