### PR TITLE
Update UserGroups management with add/modify/delete options

### DIFF
--- a/src/groups/user_group_repository.py
+++ b/src/groups/user_group_repository.py
@@ -10,13 +10,20 @@ class UserGroupRepository:
         self.db = get_client()
 
     def get_user_groups(self) -> List[Dict[str, Any]]:
-        return self.db.query(self.collection, order_by='createdAt', direction='DESCENDING')
+        filters = [('status', '!=', 'deleted')]
+        return self.db.query(self.collection, filters=filters, order_by='createdAt', direction='DESCENDING')
 
     def create_user_group(self, data: Dict[str, Any]) -> str:
         return self.db.create(self.collection, data)
 
     def update_user_group(self, doc_id: str, data: Dict[str, Any]) -> bool:
         return self.db.update(self.collection, doc_id, data)
+
+    def get_user_group(self, doc_id: str) -> Dict[str, Any] | None:
+        return self.db.read(self.collection, doc_id)
+
+    def delete_user_group(self, doc_id: str) -> bool:
+        return self.db.update(self.collection, doc_id, {'status': 'deleted'})
 
 _repo: UserGroupRepository | None = None
 

--- a/src/groups/user_group_service.py
+++ b/src/groups/user_group_service.py
@@ -17,6 +17,12 @@ class UserGroupService:
     def update_user_group(self, doc_id: str, data: Dict[str, Any]) -> bool:
         return self.repo.update_user_group(doc_id, data)
 
+    def get_user_group(self, doc_id: str) -> Dict[str, Any] | None:
+        return self.repo.get_user_group(doc_id)
+
+    def delete_user_group(self, doc_id: str) -> bool:
+        return self.repo.delete_user_group(doc_id)
+
 _service: UserGroupService | None = None
 
 def get_user_group_service() -> UserGroupService:

--- a/src/ui/group_management.py
+++ b/src/ui/group_management.py
@@ -23,21 +23,31 @@ def _user_groups_tab():
     service = get_user_group_service()
     records = service.get_user_groups()
     st.dataframe(records)
-    options = [''] + [r['id'] for r in records]
-    record_id = st.selectbox('Record', options)
-    group_id = st.text_input('GroupId')
-    group_name = st.text_input('GroupName')
-    user_id = st.text_input('UserId')
-    user_name = st.text_input('UserName')
-    user_email = st.text_input('UserEmail')
-    if st.button('Save UserGroup'):
-        data = {'groupId': group_id, 'groupName': group_name, 'userId': user_id, 'userName': user_name, 'userEmail': user_email}
-        if record_id:
-            service.update_user_group(record_id, data)
-        else:
+    action = st.radio('Action', ['Add new record', 'Modify existing record'])
+    if action == 'Add new record':
+        group_name = st.text_input('Group Name')
+        user_email = st.text_input('User Email')
+        if st.button('Add'):
+            data = {'groupName': group_name, 'userEmail': user_email, 'status': 'active'}
             service.create_user_group(data)
-        st.success('Saved')
-        st.rerun()
+            st.success('Saved')
+            st.rerun()
+    else:
+        options = [''] + [r['id'] for r in records]
+        record_id = st.selectbox('RecordId', options)
+        record = next((r for r in records if r['id'] == record_id), {}) if record_id else {}
+        group_name = st.text_input('Group Name', value=record.get('groupName', ''))
+        user_email = st.text_input('User Email', value=record.get('userEmail', ''))
+        cols = st.columns(2)
+        if cols[0].button('Update') and record_id:
+            data = {'groupName': group_name, 'userEmail': user_email}
+            service.update_user_group(record_id, data)
+            st.success('Saved')
+            st.rerun()
+        if cols[1].button('Delete') and record_id:
+            service.delete_user_group(record_id)
+            st.success('Deleted')
+            st.rerun()
 
 
 def render_group_management():

--- a/tests/test_group_services.py
+++ b/tests/test_group_services.py
@@ -42,6 +42,10 @@ class DummyUserGroupRepo:
         self.calls.append(('update', uid, data))
         return True
 
+    def delete_user_group(self, uid):
+        self.calls.append(('delete', uid))
+        return True
+
 
 def test_group_service(monkeypatch):
     repo = DummyRepo()
@@ -60,4 +64,5 @@ def test_user_group_service(monkeypatch):
     service.get_user_groups()
     service.create_user_group({'a': 1})
     service.update_user_group('u', {'b': 2})
-    assert repo.calls == ['get', ('create', {'a': 1}), ('update', 'u', {'b': 2})]
+    service.delete_user_group('u')
+    assert repo.calls == ['get', ('create', {'a': 1}), ('update', 'u', {'b': 2}), ('delete', 'u')]


### PR DESCRIPTION
## Summary
- support soft deletes for UserGroups in repository and service
- update UserGroups tab to allow adding, updating and deleting records
- test new user group operations

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68466d8a663c8332b00abbcc90054a9b