### PR TITLE
Update UserGroups management UI

### DIFF
--- a/src/users/user_repository.py
+++ b/src/users/user_repository.py
@@ -24,6 +24,9 @@ class UserRepository:
             record['userName'] = name
         return record
 
+    def get_users(self):
+        return self.db.get_all(self.collection)
+
 _repo: Optional[UserRepository] = None
 
 def get_user_repository() -> UserRepository:

--- a/src/users/user_service.py
+++ b/src/users/user_service.py
@@ -17,6 +17,9 @@ class UserService:
         self.role_service.ensure_default_role(record['userId'])
         return record
 
+    def get_users(self):
+        return self.repo.get_users()
+
 _service: UserService | None = None
 
 def get_user_service() -> UserService:


### PR DESCRIPTION
## Summary
- split UserGroups tab into Add and Remove sections
- allow adding user to group by dropdown selection
- remove user from group with delete option
- expose `get_users` in user repo and service
- adjust tests for new workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6847437d93f48332a7ce46936004b29f