### PR TITLE
Implement user timezone setting page

### DIFF
--- a/pages/settings.py
+++ b/pages/settings.py
@@ -1,0 +1,9 @@
+import streamlit as st
+from src.ui.settings import render_settings
+
+def main():
+    st.title('Settings')
+    render_settings()
+
+if __name__ == '__main__':
+    main()

--- a/src/groups/user_group_service.py
+++ b/src/groups/user_group_service.py
@@ -23,6 +23,10 @@ class UserGroupService:
     def delete_user_group(self, doc_id: str) -> bool:
         return self.repo.delete_user_group(doc_id)
 
+    def get_groups_for_user(self, user_id: str) -> List[Dict[str, Any]]:
+        records = self.repo.get_user_groups()
+        return [r for r in records if (r.get('userId') == user_id or r.get('userEmail') == user_id) and r.get('status') != 'deleted']
+
 _service: UserGroupService | None = None
 
 def get_user_group_service() -> UserGroupService:

--- a/src/ui/navigation.py
+++ b/src/ui/navigation.py
@@ -7,6 +7,7 @@ from src.ui.task_form import render_task_form
 from src.ui.ai_chat import render_ai_chat
 from src.ui.prompt_management import render_prompt_management
 from src.ui.group_management import render_group_management
+from src.ui.settings import render_settings
 from src.ui.summary import render_summary
 from src.ui.changelog import render_changelog
 from src.ai.chat_service import delete_all_chats_one_by_one, get_all_chats
@@ -79,6 +80,9 @@ def prompt_management_page():
 
 def group_management_page():
     render_group_management()
+
+def settings_page():
+    render_settings()
 
 def summary_page():
     render_summary()
@@ -181,6 +185,7 @@ def render_main_page():
     ai_page = st.Page(ai_assistant_page, title='AI Assistant', icon='🤖')
     prompt_page = st.Page(prompt_management_page, title='Prompt Management', icon='📝')
     group_page = st.Page(group_management_page, title='Group Management', icon='👥')
+    settings_nav = st.Page(settings_page, title='Settings', icon='⚙️')
     summary_nav = st.Page(summary_page, title='Summary', icon='📋')
     changelog_nav = st.Page(changelog_page, title='ChangeLog', icon='📜')
     run_tests_nav = st.Page(run_tests_page, title='Run Tests', icon='🧪')
@@ -190,7 +195,7 @@ def render_main_page():
 
     ai_pages = [ai_page]
     user_pages = [active_page, completed_page, deleted_page]
-    navigation_pages = [summary_nav, changelog_nav, run_tests_nav]
+    navigation_pages = [settings_nav, summary_nav, changelog_nav, run_tests_nav]
     admin_pages = [prompt_page, group_page, eval_candidates_nav, run_evals_nav, debug_page_nav]
     page = st.navigation({'============= 🧑\u200d💼 AI': ai_pages,'============= 🧑\u200d💼 User': user_pages, '============= 🧭 Nav': navigation_pages, '============= 🛠️ Admin': admin_pages})
     page.run()

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -1,0 +1,21 @@
+import streamlit as st
+from zoneinfo import available_timezones
+from src.users.user_service import get_user_service
+from src.groups.user_group_service import get_user_group_service
+
+def render_settings():
+    st.header('Settings')
+    user = st.session_state.user or {}
+    st.write(f"Name: {user.get('name','')}")
+    st.write(f"Email: {user.get('email','')}")
+    groups = get_user_group_service().get_groups_for_user(st.session_state.userId)
+    group_names = ', '.join(g.get('groupName','') for g in groups)
+    st.write(f"Groups: {group_names}")
+    options = sorted(available_timezones())
+    current = st.session_state.get('userTZ','America/Los_Angeles')
+    value = st.selectbox('Timezone', options, index=options.index(current) if current in options else 0)
+    if st.button('Save'):
+        if get_user_service().update_timezone(st.session_state.userId, value):
+            st.session_state.userTZ = value
+            st.success('Saved')
+

--- a/src/users/user_repository.py
+++ b/src/users/user_repository.py
@@ -24,6 +24,9 @@ class UserRepository:
             record['userName'] = name
         return record
 
+    def update_user_timezone(self, user_id: str, tz: str) -> bool:
+        return self.db.update(self.collection, user_id, {'userTZ': tz})
+
     def get_users(self):
         return self.db.get_all(self.collection)
 

--- a/src/users/user_service.py
+++ b/src/users/user_service.py
@@ -20,6 +20,9 @@ class UserService:
     def get_users(self):
         return self.repo.get_users()
 
+    def update_timezone(self, user_id: str, tz: str) -> bool:
+        return self.repo.update_user_timezone(user_id, tz)
+
 _service: UserService | None = None
 
 def get_user_service() -> UserService:

--- a/tests/test_group_services.py
+++ b/tests/test_group_services.py
@@ -47,6 +47,8 @@ class DummyUserGroupRepo:
         return True
 
 
+
+
 def test_group_service(monkeypatch):
     repo = DummyRepo()
     monkeypatch.setattr('src.groups.group_service.get_group_repository', lambda: repo)
@@ -66,3 +68,12 @@ def test_user_group_service(monkeypatch):
     service.update_user_group('u', {'b': 2})
     service.delete_user_group('u')
     assert repo.calls == ['get', ('create', {'a': 1}), ('update', 'u', {'b': 2}), ('delete', 'u')]
+
+def test_get_groups_for_user(monkeypatch):
+    record = {'userId': 'u1', 'groupName': 'G', 'status': 'active'}
+    repo = DummyUserGroupRepo()
+    repo.get_user_groups = lambda: [record]
+    monkeypatch.setattr('src.groups.user_group_service.get_user_group_repository', lambda: repo)
+    service = UserGroupService()
+    groups = service.get_groups_for_user('u1')
+    assert groups == [record]

--- a/tests/test_settings_ui.py
+++ b/tests/test_settings_ui.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'src'))
+
+st = ModuleType('streamlit')
+
+class SessionState(dict):
+    def __getattr__(self, name):
+        return self.get(name)
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+st.session_state = SessionState({'userId': 'u1', 'user': {'name': 'N', 'email': 'E'}, 'userTZ': 'America/Los_Angeles'})
+st.header = lambda *a, **k: None
+st.write = lambda *a, **k: None
+st.selectbox = lambda *a, **k: 'UTC'
+st.button = lambda *a, **k: True
+st.success = lambda *a, **k: None
+sys.modules['streamlit'] = st
+
+import importlib
+import src.ui.settings as settings
+importlib.reload(settings)
+
+
+def test_render_settings(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(settings, 'get_user_group_service', lambda: SimpleNamespace(get_groups_for_user=lambda uid: [{'groupName': 'G'}]))
+    monkeypatch.setattr(settings, 'get_user_service', lambda: SimpleNamespace(update_timezone=lambda uid, tz: calls.setdefault('update', (uid, tz)) or True))
+    settings.render_settings()
+    assert calls['update'][1] == 'UTC'
+

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -17,6 +17,9 @@ class DummyRepo:
         if name:
             rec['userName'] = name
         return rec
+    def update_user_timezone(self, user_id, tz):
+        self.calls.append(('update_tz', user_id, tz))
+        return True
 
 class DummyRoleService:
     def __init__(self):
@@ -46,3 +49,12 @@ def test_login_new(monkeypatch):
     assert record['userTZ'] == 'America/Los_Angeles'
     assert repo.calls == [('get', 'n'), ('create', 'n', 'America/Los_Angeles', 'Name')]
     assert roles.calls == ['n1']
+
+def test_update_timezone(monkeypatch):
+    repo = DummyRepo()
+    monkeypatch.setattr('src.users.user_service.get_user_repository', lambda: repo)
+    monkeypatch.setattr('src.users.user_service.get_user_role_service', lambda: DummyRoleService())
+    service = UserService()
+    result = service.update_timezone('u1', 'UTC')
+    assert result is True
+    assert repo.calls[-1] == ('update_tz', 'u1', 'UTC')


### PR DESCRIPTION
## Summary
- add user timezone update capability
- show groups for user in settings page and update timezone
- expose settings page in sidebar navigation
- support querying groups for a user
- test timezone updates and UI settings page

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68476b571b08833280d1e24aacc67db2