### PR TITLE
Add timezone-aware timestamps

### DIFF
--- a/src/ui/prompt_management.py
+++ b/src/ui/prompt_management.py
@@ -1,6 +1,8 @@
 import streamlit as st
+
 from src.ai.prompt_service import get_prompt_service
 from src.database.models import PromptStatus
+from src.utils.time_utils import format_user_tz
 
 def render_prompt_management():
     st.header('Prompt Management')
@@ -38,7 +40,7 @@ def render_prompt_management():
                 st.error(f'Failed to create new version: {e}')
     with st.form(key='change_active_version'):
         st.subheader('Change Active version')
-        options = {f"v{p.version} - {(p.created_at.strftime('%Y-%m-%d %H:%M:%S') if p.created_at else 'unknown')}": p.version for p in selected}
+        options = {f"v{p.version} - {(format_user_tz(p.created_at, '%Y-%m-%d %H:%M:%S') if p.created_at else 'unknown')}": p.version for p in selected}
         current_version = active_prompt.version if active_prompt else None
         version_choice = st.selectbox('Select Version', list(options.keys()), index=list(options.values()).index(current_version) if current_version in options.values() else 0)
         update = st.form_submit_button('Update')

--- a/src/ui/summary.py
+++ b/src/ui/summary.py
@@ -1,9 +1,12 @@
 import os
 from datetime import datetime, timedelta
+
 import streamlit as st
 from langchain_community.chat_models import ChatOpenAI
 from langchain_core.messages import HumanMessage, SystemMessage
+
 from src.tasks.task_service import get_task_service
+from src.utils.time_utils import format_user_tz
 
 def render_summary():
     st.header('Weekly Summary')
@@ -36,7 +39,7 @@ def render_summary():
     else:
         st.write('Here are the latest updates:')
         for ts, title, text in recent_updates[:5]:
-            st.markdown(f"- **{ts.strftime('%Y-%m-%d')}**: {text} - *{title}*")
+            st.markdown(f"- **{format_user_tz(ts, '%Y-%m-%d')}**: {text} - *{title}*")
 
 def _summarize_updates(updates):
     api_key = os.environ.get('OPENAI_API_KEY')
@@ -44,7 +47,7 @@ def _summarize_updates(updates):
         return None
     try:
         chat = ChatOpenAI(api_key=api_key, model=os.environ.get('OPENAI_MODEL', 'gpt-4.1-mini'), temperature=0)
-        updates_text = '\n'.join((f"- {ts.strftime('%Y-%m-%d')}: {text} ({title})" for ts, title, text in updates))
+        updates_text = '\n'.join((f"- {format_user_tz(ts, '%Y-%m-%d')}: {text} ({title})" for ts, title, text in updates))
         prompt = f'Summarize the following task updates in 3-5 bullet points:\n{updates_text}'
         messages = [SystemMessage(content='You are a helpful assistant that summarizes task updates.'), HumanMessage(content=prompt)]
         response = chat.invoke(messages)

--- a/src/ui/task_list.py
+++ b/src/ui/task_list.py
@@ -1,8 +1,11 @@
-import streamlit as st
 from datetime import datetime
-from typing import List, Callable
+from typing import Callable, List
+
+import streamlit as st
+
 from src.database.models import Task, TaskStatus
 from src.tasks.task_service import get_task_service
+from src.utils.time_utils import format_user_tz
 
 def render_task_list(tasks: List[Task], status: str, on_refresh: Callable=None):
     if not tasks:
@@ -36,21 +39,13 @@ def render_task_list(tasks: List[Task], status: str, on_refresh: Callable=None):
             if status == TaskStatus.ACTIVE:
                 row = st.columns([3, 1, 2, 1])
                 row[0].write(task.title)
-                if task.due_date:
-                    due_date_str = task.due_date.strftime('%Y-%m-%d') if isinstance(task.due_date, datetime) else task.due_date
-                    row[1].write(due_date_str)
-                else:
-                    row[1].write('N/A')
+                row[1].write(format_user_tz(task.due_date, '%Y-%m-%d') if task.due_date else 'N/A')
                 action_col = row[2]
                 details_col = row[3]
             else:
                 row = st.columns([3, 2, 2, 1])
                 row[0].write(task.title)
-                if task.due_date:
-                    due_date_str = task.due_date.strftime('%Y-%m-%d') if isinstance(task.due_date, datetime) else task.due_date
-                    row[1].write(due_date_str)
-                else:
-                    row[1].write('N/A')
+                row[1].write(format_user_tz(task.due_date, '%Y-%m-%d') if task.due_date else 'N/A')
                 action_col = row[2]
                 details_col = row[3]
             if status == TaskStatus.ACTIVE:
@@ -106,8 +101,8 @@ def render_task_list(tasks: List[Task], status: str, on_refresh: Callable=None):
                         st.subheader('Task History')
                         for update in sorted(task.updates, key=lambda x: x.get('timestamp', datetime.min), reverse=True):
                             timestamp = update.get('timestamp')
-                            timestamp_str = timestamp.strftime('%Y-%m-%d %H:%M') if isinstance(timestamp, datetime) else str(timestamp)
-                            st.text(f"{timestamp_str}: {update.get('updateText', 'Updated')}")
+                            ts = format_user_tz(timestamp)
+                            st.text(f"{ts}: {update.get('updateText', 'Updated')}")
             st.markdown("<hr class='task-separator'>", unsafe_allow_html=True)
 
 def render_active_tasks():

--- a/src/utils/time_utils.py
+++ b/src/utils/time_utils.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import streamlit as st
+
+
+def format_user_tz(value, fmt='%Y-%m-%d %H:%M'):
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value)
+        except ValueError:
+            return value
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.utcnow().astimezone().tzinfo)
+    name = st.session_state.get('userTZ') or 'UTC'
+    if name == 'Z':
+        name = 'UTC'
+    try:
+        tz = ZoneInfo(name)
+    except Exception:
+        tz = ZoneInfo('UTC')
+    return value.astimezone(tz).strftime(fmt)

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,31 @@
+import sys
+import importlib
+from pathlib import Path
+from types import ModuleType
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'src'))
+
+
+def _load(monkeypatch):
+    st = ModuleType('streamlit')
+    st.session_state = {}
+    monkeypatch.setitem(sys.modules, 'streamlit', st)
+    mod = importlib.reload(importlib.import_module('src.utils.time_utils'))
+    return st, mod
+
+
+def test_format_user_tz_basic(monkeypatch):
+    st, mod = _load(monkeypatch)
+    st.session_state['userTZ'] = 'America/New_York'
+    dt = datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo('UTC'))
+    assert mod.format_user_tz(dt) == dt.astimezone(ZoneInfo('America/New_York')).strftime('%Y-%m-%d %H:%M')
+
+
+def test_format_user_tz_invalid_string(monkeypatch):
+    st, mod = _load(monkeypatch)
+    st.session_state['userTZ'] = 'UTC'
+    assert mod.format_user_tz('bad') == 'bad'


### PR DESCRIPTION
## Summary
- convert displayed timestamps to user's timezone
- centralize timezone formatting
- test timezone formatting

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68476b9f440c8332908f6861cc27e275