### PR TITLE
Add owner info and assignment UI

### DIFF
--- a/pages/task_assignment.py
+++ b/pages/task_assignment.py
@@ -1,0 +1,10 @@
+import streamlit as st
+from src.ui.task_assignment import render_task_assignment
+
+
+def main():
+    render_task_assignment()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -13,7 +13,7 @@ class PromptStatus(str, Enum):
 
 class Task:
 
-    def __init__(self, id: Optional[str]=None, user_id: str=None, title: str=None, description: str=None, due_date: Optional[datetime]=None, status: str=TaskStatus.ACTIVE, created_at: Optional[datetime]=None, updated_at: Optional[datetime]=None, completion_date: Optional[datetime]=None, deletion_date: Optional[datetime]=None, notes: str=None, updates: List[Dict[str, Any]]=None):
+    def __init__(self, id: Optional[str]=None, user_id: str=None, title: str=None, description: str=None, due_date: Optional[datetime]=None, status: str=TaskStatus.ACTIVE, created_at: Optional[datetime]=None, updated_at: Optional[datetime]=None, completion_date: Optional[datetime]=None, deletion_date: Optional[datetime]=None, notes: str=None, updates: List[Dict[str, Any]]=None, owner_id: Optional[str]=None, owner_email: Optional[str]=None, owner_name: Optional[str]=None):
         self.id = id
         self.user_id = user_id
         self.title = title
@@ -26,10 +26,13 @@ class Task:
         self.deletion_date = deletion_date
         self.notes = notes
         self.updates = updates or []
+        self.owner_id = owner_id
+        self.owner_email = owner_email
+        self.owner_name = owner_name
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'Task':
-        return cls(id=data.get('id'), user_id=data.get('userId'), title=data.get('title'), description=data.get('description'), due_date=data.get('dueDate'), status=data.get('status', TaskStatus.ACTIVE), created_at=data.get('createdAt'), updated_at=data.get('updatedAt'), completion_date=data.get('completionDate'), deletion_date=data.get('deletionDate'), notes=data.get('notes'), updates=data.get('updates', []))
+        return cls(id=data.get('id'), user_id=data.get('userId'), title=data.get('title'), description=data.get('description'), due_date=data.get('dueDate'), status=data.get('status', TaskStatus.ACTIVE), created_at=data.get('createdAt'), updated_at=data.get('updatedAt'), completion_date=data.get('completionDate'), deletion_date=data.get('deletionDate'), notes=data.get('notes'), updates=data.get('updates', []), owner_id=data.get('ownerId'), owner_email=data.get('ownerEmail'), owner_name=data.get('ownerName'))
 
     def to_dict(self) -> Dict[str, Any]:
         data = {'userId': self.user_id, 'title': self.title, 'status': self.status}
@@ -47,6 +50,12 @@ class Task:
             data['notes'] = self.notes
         if self.updates:
             data['updates'] = self.updates
+        if self.owner_id:
+            data['ownerId'] = self.owner_id
+        if self.owner_email:
+            data['ownerEmail'] = self.owner_email
+        if self.owner_name:
+            data['ownerName'] = self.owner_name
         return data
 
     def validate(self) -> bool:
@@ -54,6 +63,8 @@ class Task:
             raise ValueError('User ID is required')
         if not self.title:
             raise ValueError('Title is required')
+        if not self.due_date:
+            raise ValueError('Due date is required')
         if self.status not in [s.value for s in TaskStatus]:
             raise ValueError(f'Invalid status: {self.status}')
         return True

--- a/src/tasks/task_repository.py
+++ b/src/tasks/task_repository.py
@@ -154,6 +154,20 @@ class TaskRepository:
         except Exception as e:
             logger.error(f'Error completing task {task_id}: {str(e)}')
             raise
+
+    def assign_tasks(self, task_ids: List[str], new_user_id: str) -> bool:
+        try:
+            for task_id in task_ids:
+                task_data = self.db.read(self.collection, task_id)
+                if not task_data:
+                    continue
+                updates = task_data.get('updates') or []
+                update_entry = {'timestamp': datetime.now(), 'user': new_user_id, 'updateText': 'Task assigned'}
+                self.db.update(self.collection, task_id, {'userId': new_user_id, 'updates': updates + [update_entry]})
+            return True
+        except Exception as e:
+            logger.error(f'Error assigning tasks: {str(e)}')
+            raise
 _task_repository: Optional[TaskRepository] = None
 
 def get_task_repository() -> TaskRepository:

--- a/src/tasks/task_service.py
+++ b/src/tasks/task_service.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any
 from src.database.models import Task, TaskStatus
 from src.tasks.task_repository import get_task_repository
@@ -36,7 +36,8 @@ class TaskService:
 
     def create_task(self, user_id: str, task_data: Dict[str, Any]) -> str:
         logger.info(f'Creating task for user {user_id}')
-        task = Task(user_id=user_id, title=task_data.get('title'), description=task_data.get('description'), due_date=task_data.get('due_date'), notes=task_data.get('notes'))
+        due_date = task_data.get('due_date') or datetime.now() + timedelta(days=7)
+        task = Task(user_id=user_id, title=task_data.get('title'), description=task_data.get('description'), due_date=due_date, notes=task_data.get('notes'), owner_id=task_data.get('owner_id', user_id), owner_email=task_data.get('owner_email'), owner_name=task_data.get('owner_name'))
         task.updates = [{'timestamp': datetime.now(), 'user': user_id, 'updateText': 'Task created'}]
         return self.repository.create_task(task)
 
@@ -66,6 +67,10 @@ class TaskService:
     def complete_task(self, user_id: str, task_id: str) -> bool:
         logger.info(f'Completing task {task_id} for user {user_id}')
         return self.repository.complete_task(user_id, task_id)
+
+    def assign_tasks(self, task_ids: List[str], new_user_id: str) -> bool:
+        logger.info(f'Assigning tasks {task_ids} to user {new_user_id}')
+        return self.repository.assign_tasks(task_ids, new_user_id)
 _task_service: Optional[TaskService] = None
 
 def get_task_service() -> TaskService:

--- a/src/ui/navigation.py
+++ b/src/ui/navigation.py
@@ -6,6 +6,7 @@ from src.ui.tasks_page import render_tasks_page
 from src.ui.ai_chat import render_ai_chat
 from src.ui.prompt_management import render_prompt_management
 from src.ui.group_management import render_group_management
+from src.ui.task_assignment import render_task_assignment
 from src.ui.settings import render_settings
 from src.ui.summary import render_summary
 from src.ui.changelog import render_changelog
@@ -65,6 +66,9 @@ def prompt_management_page():
 
 def group_management_page():
     render_group_management()
+
+def task_assignment_page():
+    render_task_assignment()
 
 def settings_page():
     render_settings()
@@ -171,6 +175,7 @@ def render_main_page():
     ai_page = st.Page(ai_assistant_page, title='AI Assistant', icon='🤖')
     prompt_page = st.Page(prompt_management_page, title='Prompt Management', icon='📝')
     group_page = st.Page(group_management_page, title='Group Management', icon='👥')
+    assignment_page = st.Page(task_assignment_page, title='Assign Tasks', icon='📌')
     settings_nav = st.Page(settings_page, title='Settings', icon='⚙️')
     summary_nav = st.Page(summary_page, title='Summary', icon='📋')
     changelog_nav = st.Page(changelog_page, title='ChangeLog', icon='📜')
@@ -182,6 +187,6 @@ def render_main_page():
     ai_pages = [ai_page]
     user_pages = [tasks_nav]
     navigation_pages = [settings_nav, summary_nav, changelog_nav, run_tests_nav]
-    admin_pages = [prompt_page, group_page, eval_candidates_nav, run_evals_nav, debug_page_nav]
+    admin_pages = [prompt_page, group_page, assignment_page, eval_candidates_nav, run_evals_nav, debug_page_nav]
     page = st.navigation({'============= 🧑\u200d💼 AI': ai_pages,'============= 🧑\u200d💼 User': user_pages, '============= 🧭 Nav': navigation_pages, '============= 🛠️ Admin': admin_pages})
     page.run()

--- a/src/ui/task_assignment.py
+++ b/src/ui/task_assignment.py
@@ -1,0 +1,20 @@
+import streamlit as st
+from src.tasks.task_service import get_task_service
+from src.users.user_service import get_user_service
+
+
+def render_task_assignment():
+    st.header('Assign Tasks')
+    ts = get_task_service()
+    tasks = ts.get_all_tasks()
+    users = get_user_service().get_users()
+    task_opts = {f"{t.title} ({t.user_id})": t.id for t in tasks}
+    selected_labels = st.multiselect('Tasks', list(task_opts.keys()))
+    user_opts = {u.get('userName') or u['userEmail']: u['userId'] for u in users}
+    selected_user = st.selectbox('Assign To', [''] + list(user_opts.keys()))
+    if st.button('Assign') and selected_labels and selected_user:
+        ids = [task_opts[l] for l in selected_labels]
+        if ts.assign_tasks(ids, user_opts[selected_user]):
+            st.success('Tasks assigned')
+        else:
+            st.error('Assignment failed')

--- a/src/ui/task_form.py
+++ b/src/ui/task_form.py
@@ -40,7 +40,8 @@ def render_task_form(task: Optional[Task]=None):
         due_date_value = None
         if due_date and due_date != datetime.today().date():
             due_date_value = datetime.combine(due_date, datetime.min.time())
-        task_data = {'title': title, 'description': description if description else None, 'due_date': due_date_value, 'notes': notes if notes else None}
+        user = st.session_state.user
+        task_data = {'title': title, 'description': description if description else None, 'due_date': due_date_value, 'notes': notes if notes else None, 'owner_id': user.get('userId', user.get('email')), 'owner_email': user.get('email'), 'owner_name': user.get('name')}
         if task:
             if task_service.update_task(user_id, task.id, task_data):
                 st.success('Task updated successfully!')

--- a/tests/test_task_assignment_ui.py
+++ b/tests/test_task_assignment_ui.py
@@ -1,0 +1,31 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'src'))
+
+st = ModuleType('streamlit')
+st.header = lambda *a, **k: None
+st.multiselect = lambda label, opts: [opts[0]] if opts else []
+st.selectbox = lambda label, opts: opts[1] if len(opts) > 1 else ''
+st.button = lambda *a, **k: True
+st.success = lambda *a, **k: setattr(st, 'status', 'success')
+st.error = lambda *a, **k: setattr(st, 'status', 'error')
+st.session_state = {}
+sys.modules['streamlit'] = st
+
+import importlib
+import src.ui.task_assignment as ta
+importlib.reload(ta)
+
+
+def test_render_task_assignment(monkeypatch):
+    tasks = [SimpleNamespace(id='1', title='A', user_id='u1')]
+    users = [{'userId': 'u2', 'userEmail': 'e'}]
+    service = SimpleNamespace(get_all_tasks=lambda: tasks, assign_tasks=lambda ids, uid: setattr(st, 'assigned', (ids, uid)))
+    monkeypatch.setattr(ta, 'get_task_service', lambda: service)
+    monkeypatch.setattr(ta, 'get_user_service', lambda: SimpleNamespace(get_users=lambda: users))
+    ta.render_task_assignment()
+    assert getattr(st, 'assigned', None) == (['1'], 'u2')

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -43,3 +43,8 @@ def test_get_all_tasks_for_user(monkeypatch):
     result = service.get_all_tasks_for_user('u1')
     assert result == ['task1']
     repo.get_all_tasks_for_user.assert_called_once_with('u1')
+
+def test_assign_tasks(monkeypatch):
+    service, repo = _setup_service(monkeypatch)
+    service.assign_tasks(['t1', 't2'], 'u2')
+    repo.assign_tasks.assert_called_once_with(['t1', 't2'], 'u2')


### PR DESCRIPTION
## Summary
- include ownerId, ownerEmail and ownerName in Task model
- default due dates and enforce they are present
- allow assigning tasks to other users
- add UI for admins to assign tasks
- update navigation and form handling
- add unit tests for new functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477a24b7a48332aaea4bda243540ac