### PR TITLE
Add SSO entry point

### DIFF
--- a/app_auth2.py
+++ b/app_auth2.py
@@ -1,0 +1,40 @@
+import os
+import logging
+import streamlit as st
+from dotenv import load_dotenv
+from src.ui.navigation import render_main_page, render_sidebar
+from src.auth.session import init_session, login_user, logout_user as session_logout_user
+
+load_dotenv()
+for key, value in st.secrets.items():
+    os.environ[str(key)] = str(value)
+logging_level = os.environ.get('LOG_LEVEL', 'INFO')
+numeric_level = getattr(logging, logging_level.upper(), logging.INFO)
+logging.basicConfig(level=numeric_level, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+st.set_page_config(page_title='Task Management System', page_icon='✅', layout='wide', initial_sidebar_state='expanded')
+init_session()
+
+
+def main():
+    if not st.user.is_logged_in:
+        if st.button('Log in'):
+            st.login()
+        st.stop()
+    if st.button('Logout'):
+        st.logout()
+        session_logout_user()
+        st.stop()
+    user_info = {'id': st.user.id, 'email': st.user.email, 'name': st.user.name}
+    if st.session_state.user != user_info:
+        login_user(user_info)
+    render_sidebar()
+    render_main_page()
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        logger.error(f'Application error: {str(e)}')
+        st.error(f'An error occurred: {str(e)}')

--- a/tests/test_app_auth2.py
+++ b/tests/test_app_auth2.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+
+st = ModuleType('streamlit')
+nav = ModuleType('src.ui.navigation')
+nav.render_main_page = lambda: None
+nav.render_sidebar = lambda: None
+sys.modules['src.ui.navigation'] = nav
+db = ModuleType('src.database.firestore')
+db.get_client = lambda: None
+sys.modules['src.database.firestore'] = db
+
+class SessionState(dict):
+    def __getattr__(self, name):
+        return self.get(name)
+    def __setattr__(self, name, value):
+        self[name] = value
+
+st.session_state = SessionState({'user': None})
+st.secrets = {}
+st.set_page_config = lambda *a, **k: None
+calls = {}
+
+class Stop(Exception):
+    pass
+st.button = lambda label, on_click=None: calls.setdefault(label, False)
+st.login = lambda *a, **k: calls.setdefault('login', True)
+st.logout = lambda *a, **k: calls.setdefault('logout', True)
+def _stop():
+    calls.setdefault('stop', True)
+    raise Stop()
+st.stop = _stop
+st.user = SimpleNamespace(is_logged_in=False, id=None, email=None, name=None)
+
+sys.modules['streamlit'] = st
+
+import app_auth2
+
+
+def test_not_logged_in(monkeypatch):
+    calls.clear()
+    try:
+        app_auth2.main()
+    except Stop:
+        pass
+    assert 'stop' in calls
+
+
+def test_logged_in(monkeypatch):
+    st.user.is_logged_in = True
+    st.user.id = '1'
+    st.user.email = 'e'
+    st.user.name = 'n'
+    calls.clear()
+    recorded = {}
+    monkeypatch.setattr(app_auth2, 'render_sidebar', lambda: recorded.setdefault('sidebar', True))
+    monkeypatch.setattr(app_auth2, 'render_main_page', lambda: recorded.setdefault('main', True))
+    monkeypatch.setattr(app_auth2, 'login_user', lambda info: recorded.setdefault('user', info))
+    app_auth2.main()
+    assert recorded['user']['email'] == 'e'
+    assert recorded.get('sidebar') and recorded.get('main')


### PR DESCRIPTION
## Summary
- add new Streamlit SSO entrypoint `app_auth2.py`
- test login flows for new entrypoint

## Testing
- `LANGCHAIN_API_KEY=foo LANGSMITH_TRACING_V2=0 pytest -v tests/test_app_auth2.py`

------
https://chatgpt.com/codex/tasks/task_e_6847ae9ce61c83328f8e481f04e7351a