### PR TITLE
Implement assign field on task form and restrict assignment list

### DIFF
--- a/src/ui/task_assignment.py
+++ b/src/ui/task_assignment.py
@@ -1,12 +1,13 @@
 import streamlit as st
 from src.tasks.task_service import get_task_service
 from src.users.user_service import get_user_service
+from src.database.models import TaskStatus
 
 
 def render_task_assignment():
     st.header('Assign Tasks')
     ts = get_task_service()
-    tasks = ts.get_all_tasks()
+    tasks = [t for t in ts.get_all_tasks() if t.status == TaskStatus.ACTIVE]
     users = get_user_service().get_users()
     task_opts = {f"{t.title} ({t.user_id})": t.id for t in tasks}
     selected_labels = st.multiselect('Tasks', list(task_opts.keys()))

--- a/tests/test_app_auth2.py
+++ b/tests/test_app_auth2.py
@@ -34,7 +34,7 @@ def _stop():
     calls.setdefault('stop', True)
     raise Stop()
 st.stop = _stop
-st.user = SimpleNamespace(is_logged_in=False, id=None, email=None, name=None)
+st.user = SimpleNamespace(is_logged_in=False, id=None, email=None, name=None, sub=None, picture=None)
 
 sys.modules['streamlit'] = st
 
@@ -53,6 +53,7 @@ def test_not_logged_in(monkeypatch):
 def test_logged_in(monkeypatch):
     st.user.is_logged_in = True
     st.user.id = '1'
+    st.user.sub = '1'
     st.user.email = 'e'
     st.user.name = 'n'
     calls.clear()

--- a/tests/test_debug_page_ui.py
+++ b/tests/test_debug_page_ui.py
@@ -44,6 +44,7 @@ sys.modules['streamlit'] = st
 pd = ModuleType('pandas')
 pd.DataFrame = lambda data=None: data
 sys.modules['pandas'] = pd
+sys.modules.pop('src.ui.navigation', None)
 import src.ui.navigation as navigation
 
 def test_debug_page_tabs_and_delete(monkeypatch):

--- a/tests/test_task_assignment_ui.py
+++ b/tests/test_task_assignment_ui.py
@@ -8,7 +8,11 @@ sys.path.append(str(root / 'src'))
 
 st = ModuleType('streamlit')
 st.header = lambda *a, **k: None
-st.multiselect = lambda label, opts: [opts[0]] if opts else []
+captured = {}
+def _multiselect(label, opts):
+    captured['opts'] = opts
+    return [opts[0]] if opts else []
+st.multiselect = _multiselect
 st.selectbox = lambda label, opts: opts[1] if len(opts) > 1 else ''
 st.button = lambda *a, **k: True
 st.success = lambda *a, **k: setattr(st, 'status', 'success')
@@ -22,10 +26,14 @@ importlib.reload(ta)
 
 
 def test_render_task_assignment(monkeypatch):
-    tasks = [SimpleNamespace(id='1', title='A', user_id='u1')]
+    tasks = [
+        SimpleNamespace(id='1', title='A', user_id='u1', status='active'),
+        SimpleNamespace(id='2', title='B', user_id='u1', status='completed'),
+    ]
     users = [{'userId': 'u2', 'userEmail': 'e'}]
     service = SimpleNamespace(get_all_tasks=lambda: tasks, assign_tasks=lambda ids, uid: setattr(st, 'assigned', (ids, uid)))
     monkeypatch.setattr(ta, 'get_task_service', lambda: service)
     monkeypatch.setattr(ta, 'get_user_service', lambda: SimpleNamespace(get_users=lambda: users))
     ta.render_task_assignment()
     assert getattr(st, 'assigned', None) == (['1'], 'u2')
+    assert captured['opts'] == ["A (u1)"]


### PR DESCRIPTION
## Summary
- add user select to assign when creating a task
- filter task options by `active` status when assigning
- fix task assignment UI test for filtering
- clean up streamlit stubs in UI tests

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6847b9b04ca88332a06f4c02ce6111fc