### PR TITLE
Implement View Tables and Danger Zone pages

### DIFF
--- a/documentation/navigation_update.md
+++ b/documentation/navigation_update.md
@@ -45,29 +45,31 @@ def deleted_tasks_page():
 def ai_assistant_page():
     render_ai_chat()
 
-def debug_page():
+def view_tables_page():
     st.header("Debug Information: Session State")
-    # Convert session state to a readable format
     session_items = {}
     for key, value in st.session_state.items():
-        # Handle complex objects
         if hasattr(value, '__dict__'):
             session_items[key] = str(value)
         else:
             session_items[key] = value
-    
-    # Display session state as JSON
     st.json(session_items)
+
+
+def danger_zone_page():
+    st.header("Danger Zone")
+    st.button("Delete AI Chats")
 
 # Define pages for navigation
 active_page = st.Page(active_tasks_page, title="Active Tasks", icon="✅", default=True)
 completed_page = st.Page(completed_tasks_page, title="Completed Tasks", icon="✨")
 deleted_page = st.Page(deleted_tasks_page, title="Deleted Tasks", icon="🗑️")
 ai_page = st.Page(ai_assistant_page, title="AI Assistant", icon="🤖")
-debug_page_nav = st.Page(debug_page, title="Debug", icon="🐞")
+view_tables_nav = st.Page(view_tables_page, title="View Tables", icon="🐞")
+danger_zone_nav = st.Page(danger_zone_page, title="Danger Zone", icon="🐞")
 
 # Create navigation
-page = st.navigation([active_page, completed_page, deleted_page, ai_page, debug_page_nav])
+page = st.navigation([active_page, completed_page, deleted_page, ai_page, view_tables_nav, danger_zone_nav])
 
 # Run the selected page
 page.run()

--- a/documentation/user_guide.md
+++ b/documentation/user_guide.md
@@ -35,7 +35,7 @@ The sidebar displays:
 The navigation menu contains grouped sections:
 - **🧑‍💼 User**: Active Tasks, Completed Tasks, Deleted Tasks, AI Assistant
 - **🧭 Nav**: Settings
-- **🛠️ Admin**: System Management, Evals, Debug
+- **🛠️ Admin**: System Management, Evals, View Tables, Danger Zone
 
 ## 4. Managing Tasks
 

--- a/src/ui/navigation.py
+++ b/src/ui/navigation.py
@@ -126,9 +126,17 @@ def _debug_user_tables_tab():
     roles_df = pd.DataFrame(client.get_all('user_roles'))
     st.dataframe(roles_df)
 
-def debug_page():
+def view_tables_page():
     st.header('Debug Information')
-    tabs = st.tabs(['Session State', 'AI Chats', 'Tasks', 'Prompts', 'AI Eval Inputs', 'AI Eval Results', 'Users and Roles', 'Delete AI Chats'])
+    tabs = st.tabs([
+        'Session State',
+        'AI Chats',
+        'Tasks',
+        'Prompts',
+        'AI Eval Inputs',
+        'AI Eval Results',
+        'Users and Roles',
+    ])
     with tabs[0]:
         _debug_session_state_tab()
     with tabs[1]:
@@ -143,7 +151,12 @@ def debug_page():
         _debug_eval_results_tab()
     with tabs[6]:
         _debug_user_tables_tab()
-    with tabs[7]:
+
+
+def danger_zone_page():
+    st.header('Danger Zone')
+    tabs = st.tabs(['Delete AI Chats'])
+    with tabs[0]:
         _delete_ai_chats_tab()
 
 def render_main_page():
@@ -152,11 +165,12 @@ def render_main_page():
     settings_nav = st.Page(settings_page, title='Settings', icon='⚙️')
     system_nav = st.Page(system_management_page, title='System Management', icon='🛠️')
     evals_nav = st.Page(evals_page, title='Evals', icon='🧪')
-    debug_page_nav = st.Page(debug_page, title='Debug', icon='🐞')
+    view_tables_nav = st.Page(view_tables_page, title='View Tables', icon='🐞')
+    danger_zone_nav = st.Page(danger_zone_page, title='Danger Zone', icon='🐞')
 
     ai_pages = [ai_page]
     user_pages = [tasks_nav]
     navigation_pages = [settings_nav]
-    admin_pages = [system_nav, evals_nav, debug_page_nav]
+    admin_pages = [system_nav, evals_nav, view_tables_nav, danger_zone_nav]
     page = st.navigation({'============= 🧑\u200d💼 AI': ai_pages,'============= 🧑\u200d💼 User': user_pages, '============= 🧭 Nav': navigation_pages, '============= 🛠️ Admin': admin_pages})
     page.run()

--- a/tests/test_debug_page_ui.py
+++ b/tests/test_debug_page_ui.py
@@ -47,7 +47,7 @@ sys.modules['pandas'] = pd
 sys.modules.pop('src.ui.navigation', None)
 import src.ui.navigation as navigation
 
-def test_debug_page_tabs_and_delete(monkeypatch):
+def test_view_tables_page_tabs(monkeypatch):
     tabs_called.clear()
     expander_called.clear()
     monkeypatch.setattr('src.ui.navigation.get_all_chats', lambda: [])
@@ -56,14 +56,28 @@ def test_debug_page_tabs_and_delete(monkeypatch):
     monkeypatch.setattr('src.ui.navigation.get_eval_inputs', lambda: [])
     monkeypatch.setattr('src.ui.navigation.get_eval_results', lambda: [])
     monkeypatch.setattr('src.ui.navigation.get_client', lambda: SimpleNamespace(get_all=lambda c: []))
+    navigation.view_tables_page()
+    assert tabs_called and tabs_called[0] == [
+        'Session State',
+        'AI Chats',
+        'Tasks',
+        'Prompts',
+        'AI Eval Inputs',
+        'AI Eval Results',
+        'Users and Roles',
+    ]
+    assert not expander_called
+
+
+def test_danger_zone_delete(monkeypatch):
+    tabs_called.clear()
     delete_calls = []
     monkeypatch.setattr('src.ui.navigation.delete_all_chats_one_by_one', lambda count: delete_calls.append(count))
     monkeypatch.setattr(st, 'button', lambda *a, **k: True)
     st.checkbox = lambda *a, **k: True
-    navigation.debug_page()
-    assert tabs_called
-    assert not expander_called
+    navigation.danger_zone_page()
+    assert tabs_called and tabs_called[0] == ['Delete AI Chats']
     assert delete_calls == [1]
     st.checkbox = lambda *a, **k: False
-    navigation.debug_page()
+    navigation.danger_zone_page()
     assert delete_calls == [1]


### PR DESCRIPTION
## Summary
- split the Debug page into `view_tables_page` and `danger_zone_page`
- show the new pages in the admin navigation
- update docs for the new pages
- adapt UI tests for both pages

## Testing
- `pip install -q -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6847c94232848332b809ea6c4f2ec4cd