### PR TITLE
Add group tasks tab

### DIFF
--- a/src/ui/group_tasks.py
+++ b/src/ui/group_tasks.py
@@ -1,0 +1,17 @@
+import streamlit as st
+from src.groups.user_group_service import get_user_group_service
+from src.tasks.task_service import get_task_service
+
+
+def render_group_tasks():
+    st.header('Group Tasks')
+    ug_service = get_user_group_service()
+    groups = ug_service.get_groups_for_user(st.session_state.get('userId'))
+    names = [''] + [g.get('groupName', '') for g in groups]
+    selected = st.selectbox('Group', names)
+    if selected:
+        members = [r.get('userEmail') for r in ug_service.get_user_groups() if r.get('groupName') == selected]
+        tasks = [t for t in get_task_service().get_all_tasks() if t.user_id in members]
+        tasks.sort(key=lambda t: t.updated_at or t.created_at, reverse=True)
+        for task in tasks:
+            st.write(f"{task.title} - {task.user_id} - {task.status}")

--- a/src/ui/tasks_page.py
+++ b/src/ui/tasks_page.py
@@ -1,10 +1,11 @@
 import streamlit as st
 from src.ui.task_form import render_task_form
 from src.ui.task_list import render_active_tasks, render_completed_tasks, render_deleted_tasks
+from src.ui.group_tasks import render_group_tasks
 
 def render_tasks_page():
     st.title('Tasks')
-    tabs = st.tabs(['Active Tasks', 'Completed Tasks', 'Deleted Tasks'])
+    tabs = st.tabs(['Active Tasks', 'Completed Tasks', 'Deleted Tasks', 'Group Tasks'])
     with tabs[0]:
         if st.session_state.get('adding_task'):
             render_task_form()
@@ -16,3 +17,5 @@ def render_tasks_page():
         render_completed_tasks()
     with tabs[2]:
         render_deleted_tasks()
+    with tabs[3]:
+        render_group_tasks()

--- a/tests/test_group_tasks_ui.py
+++ b/tests/test_group_tasks_ui.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'src'))
+
+st = ModuleType('streamlit')
+st.header = lambda *a, **k: None
+captured = []
+st.write = lambda s: captured.append(s)
+st.selectbox = lambda label, opts: opts[1] if len(opts) > 1 else ''
+
+class SessionState(dict):
+    def __getattr__(self, name):
+        return self.get(name)
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+st.session_state = SessionState({'userId': 'u'})
+sys.modules['streamlit'] = st
+
+import importlib
+import src.ui.group_tasks as gt
+importlib.reload(gt)
+
+
+def test_render_group_tasks(monkeypatch):
+    tasks = [
+        SimpleNamespace(title='A', user_id='a', status='active', updated_at=1, created_at=1),
+        SimpleNamespace(title='B', user_id='b', status='completed', updated_at=2, created_at=2),
+    ]
+    ug_service = SimpleNamespace(
+        get_groups_for_user=lambda uid: [{'groupName': 'G'}],
+        get_user_groups=lambda: [{'groupName': 'G', 'userEmail': 'a'}, {'groupName': 'G', 'userEmail': 'b'}],
+    )
+    monkeypatch.setattr(gt, 'get_user_group_service', lambda: ug_service)
+    monkeypatch.setattr(gt, 'get_task_service', lambda: SimpleNamespace(get_all_tasks=lambda: tasks))
+    captured.clear()
+    gt.render_group_tasks()
+    assert captured == ['B - b - completed', 'A - a - active']

--- a/tests/test_tasks_page_ui.py
+++ b/tests/test_tasks_page_ui.py
@@ -36,6 +36,7 @@ def test_render_tasks_page(monkeypatch):
     monkeypatch.setattr(tasks_page, 'render_completed_tasks', lambda: None)
     monkeypatch.setattr(tasks_page, 'render_deleted_tasks', lambda: None)
     monkeypatch.setattr(tasks_page, 'render_task_form', lambda *a, **k: None)
+    monkeypatch.setattr(tasks_page, 'render_group_tasks', lambda: None)
     tabs_called.clear()
     tasks_page.render_tasks_page()
-    assert tabs_called and tabs_called[0] == ['Active Tasks', 'Completed Tasks', 'Deleted Tasks']
+    assert tabs_called and tabs_called[0] == ['Active Tasks', 'Completed Tasks', 'Deleted Tasks', 'Group Tasks']


### PR DESCRIPTION
## Summary
- add a new `render_group_tasks` helper
- display a Group Tasks tab in the tasks page
- test UI behavior for Group Tasks
- update existing tasks page test

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6848354908188332be15f4a54f6c5b48