### PR TITLE
Implement status filter for Group Tasks

### DIFF
--- a/src/ui/group_tasks.py
+++ b/src/ui/group_tasks.py
@@ -1,6 +1,8 @@
 import streamlit as st
+from src.database.models import TaskStatus
 from src.groups.user_group_service import get_user_group_service
 from src.tasks.task_service import get_task_service
+from src.ui.task_list import render_task_list
 
 
 def render_group_tasks():
@@ -9,9 +11,9 @@ def render_group_tasks():
     groups = ug_service.get_groups_for_user(st.session_state.get('userId'))
     names = [''] + [g.get('groupName', '') for g in groups]
     selected = st.selectbox('Group', names)
+    status = st.selectbox('Status', [TaskStatus.ACTIVE, TaskStatus.COMPLETED, TaskStatus.DELETED], index=0)
     if selected:
         members = [r.get('userEmail') for r in ug_service.get_user_groups() if r.get('groupName') == selected]
-        tasks = [t for t in get_task_service().get_all_tasks() if t.user_id in members]
+        tasks = [t for t in get_task_service().get_all_tasks() if t.user_id in members and t.status == status]
         tasks.sort(key=lambda t: t.updated_at or t.created_at, reverse=True)
-        for task in tasks:
-            st.write(f"{task.title} - {task.user_id} - {task.status}")
+        render_task_list(tasks, status)


### PR DESCRIPTION
## Summary
- allow selecting status in Group Tasks
- display group tasks with same columns as main list
- test status filtering works

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_684837f90cbc83328110aa7a7c265120