### PR TITLE
Update group tasks view

### DIFF
--- a/src/ui/group_tasks.py
+++ b/src/ui/group_tasks.py
@@ -1,19 +1,130 @@
 import streamlit as st
-from src.database.models import TaskStatus
+from typing import List, Tuple
+from src.database.models import Task, TaskStatus
 from src.groups.user_group_service import get_user_group_service
 from src.tasks.task_service import get_task_service
-from src.ui.task_list import render_task_list
+from src.utils.time_utils import format_user_tz
 
 
-def render_group_tasks():
-    st.header('Group Tasks')
+def _get_group_tasks(status: str) -> List[Tuple[str, Task]]:
     ug_service = get_user_group_service()
     groups = ug_service.get_groups_for_user(st.session_state.get('userId'))
-    names = [''] + [g.get('groupName', '') for g in groups]
-    selected = st.selectbox('Group', names)
-    status = st.selectbox('Status', [TaskStatus.ACTIVE, TaskStatus.COMPLETED, TaskStatus.DELETED], index=0)
-    if selected:
-        members = [r.get('userEmail') for r in ug_service.get_user_groups() if r.get('groupName') == selected]
-        tasks = [t for t in get_task_service().get_all_tasks() if t.user_id in members and t.status == status]
-        tasks.sort(key=lambda t: t.updated_at or t.created_at, reverse=True)
-        render_task_list(tasks, status)
+    records = ug_service.get_user_groups()
+    all_tasks = get_task_service().get_all_tasks()
+    results: List[Tuple[str, Task]] = []
+    for g in groups:
+        name = g.get('groupName', '')
+        members = [r.get('userEmail') for r in records if r.get('groupName') == name]
+        for t in all_tasks:
+            if t.user_id in members and t.status == status:
+                results.append((name, t))
+    results.sort(key=lambda x: x[1].updated_at or x[1].created_at, reverse=True)
+    return results
+
+
+def _render_group_task_list(tasks: List[Tuple[str, Task]], status: str):
+    if not tasks:
+        st.info(f'No {status.lower()} tasks found.')
+        return
+    user_id = st.session_state.user.get('email')
+    if status == TaskStatus.ACTIVE:
+        header = st.columns([2, 3, 1, 2, 1])
+        header[0].write('**Group**')
+        header[1].write('**Title**')
+        header[2].write('**Due Date**')
+        header[3].write('**Actions**')
+        header[4].write('**Details**')
+    else:
+        header = st.columns([2, 3, 2, 2, 1])
+        header[0].write('**Group**')
+        header[1].write('**Title**')
+        header[2].write('**Date**')
+        header[3].write('**Actions**')
+        header[4].write('**Details**')
+    st.markdown("<hr class='task-separator'>", unsafe_allow_html=True)
+    for idx, (group_name, task) in enumerate(tasks):
+        if status == TaskStatus.ACTIVE:
+            row = st.columns([2, 3, 1, 2, 1])
+            row[0].write(group_name)
+            row[1].write(task.title)
+            row[2].write(format_user_tz(task.due_date, '%Y-%m-%d') if task.due_date else 'N/A')
+            action_col = row[3]
+            details_col = row[4]
+        else:
+            row = st.columns([2, 3, 2, 2, 1])
+            row[0].write(group_name)
+            row[1].write(task.title)
+            row[2].write(format_user_tz(task.due_date, '%Y-%m-%d') if task.due_date else 'N/A')
+            action_col = row[3]
+            details_col = row[4]
+        if status == TaskStatus.ACTIVE:
+            action_buttons = action_col.columns(3)
+            if action_buttons[0].button('✓', key=f'to_complete_{task.id}_{idx}'):
+                if get_task_service().complete_task(user_id, task.id):
+                    st.success('Task marked as completed!')
+                    st.rerun()
+                else:
+                    st.error('Failed to complete task.')
+            if action_buttons[1].button('✎', key=f'to_edit_{task.id}_{idx}'):
+                st.session_state.editing_task = task
+                st.rerun()
+            if action_buttons[2].button('🗑', key=f'to_delete_{task.id}_{idx}'):
+                if get_task_service().delete_task(user_id, task.id):
+                    st.success('Task deleted!')
+                    st.rerun()
+                else:
+                    st.error('Failed to delete task.')
+        elif status == TaskStatus.COMPLETED:
+            if action_col.button('🗑', key=f'to_delete_{task.id}_{idx}'):
+                if get_task_service().delete_task(user_id, task.id):
+                    st.success('Task deleted!')
+                    st.rerun()
+                else:
+                    st.error('Failed to delete task.')
+        elif status == TaskStatus.DELETED:
+            if action_col.button('↩', key=f'to_restore_{task.id}_{idx}'):
+                if get_task_service().restore_task(user_id, task.id):
+                    st.success('Task restored!')
+                    st.rerun()
+                else:
+                    st.error('Failed to restore task.')
+        if details_col.button('👁', key=f'details_{task.id}_{idx}'):
+            if 'task_details' not in st.session_state:
+                st.session_state.task_details = {}
+            if task.id in st.session_state.task_details:
+                del st.session_state.task_details[task.id]
+            else:
+                st.session_state.task_details[task.id] = True
+            st.rerun()
+        if 'task_details' in st.session_state and task.id in st.session_state.task_details:
+            with st.expander('Task Details', expanded=True):
+                if task.description:
+                    st.markdown(f'**Description:** {task.description}')
+                if task.notes:
+                    st.markdown(f'**Notes:** {task.notes}')
+                if task.updates and len(task.updates) > 0:
+                    st.subheader('Task History')
+                    for update in sorted(task.updates, key=lambda x: x.get('timestamp'), reverse=True):
+                        ts = format_user_tz(update.get('timestamp'))
+                        st.text(f"{ts}: {update.get('updateText', 'Updated')}")
+        st.markdown("<hr class='task-separator'>", unsafe_allow_html=True)
+
+
+def render_group_tasks(status: str):
+    tasks = _get_group_tasks(status)
+    _render_group_task_list(tasks, status)
+
+
+def render_group_active_tasks():
+    st.header('Active Tasks')
+    render_group_tasks(TaskStatus.ACTIVE)
+
+
+def render_group_completed_tasks():
+    st.header('Completed Tasks')
+    render_group_tasks(TaskStatus.COMPLETED)
+
+
+def render_group_deleted_tasks():
+    st.header('Deleted Tasks')
+    render_group_tasks(TaskStatus.DELETED)

--- a/src/ui/tasks_page.py
+++ b/src/ui/tasks_page.py
@@ -1,7 +1,15 @@
 import streamlit as st
 from src.ui.task_form import render_task_form
-from src.ui.task_list import render_active_tasks, render_completed_tasks, render_deleted_tasks
-from src.ui.group_tasks import render_group_tasks
+from src.ui.task_list import (
+    render_active_tasks,
+    render_completed_tasks,
+    render_deleted_tasks,
+)
+from src.ui.group_tasks import (
+    render_group_active_tasks,
+    render_group_completed_tasks,
+    render_group_deleted_tasks,
+)
 
 
 def render_my_tasks_page():
@@ -22,9 +30,13 @@ def render_my_tasks_page():
 
 def render_group_tasks_page():
     st.title('Group Tasks')
-    tabs = st.tabs(['Group Tasks'])
+    tabs = st.tabs(['Active Tasks', 'Completed Tasks', 'Deleted Tasks'])
     with tabs[0]:
-        render_group_tasks()
+        render_group_active_tasks()
+    with tabs[1]:
+        render_group_completed_tasks()
+    with tabs[2]:
+        render_group_deleted_tasks()
 
 
 def render_tasks_page():

--- a/tests/test_group_tasks_ui.py
+++ b/tests/test_group_tasks_ui.py
@@ -10,15 +10,7 @@ st = ModuleType('streamlit')
 st.header = lambda *a, **k: None
 captured = {}
 st.write = lambda *a, **k: None
-
-def selectbox(label, opts, index=0):
-    if label == 'Group' and len(opts) > 1:
-        return opts[1]
-    if label == 'Status' and len(opts) > 1:
-        return opts[1]
-    return opts[index] if len(opts) > index else ''
-
-st.selectbox = selectbox
+st.info = lambda *a, **k: None
 
 class SessionState(dict):
     def __getattr__(self, name):
@@ -47,9 +39,8 @@ def test_render_group_tasks(monkeypatch):
     monkeypatch.setattr(gt, 'get_user_group_service', lambda: ug_service)
     monkeypatch.setattr(gt, 'get_task_service', lambda: SimpleNamespace(get_all_tasks=lambda: tasks))
     outputs = {}
-    monkeypatch.setattr(gt, 'render_task_list', lambda ts, status: outputs.setdefault('data', (ts, status)))
-    captured.clear()
-    gt.render_group_tasks()
+    monkeypatch.setattr(gt, '_render_group_task_list', lambda ts, status: outputs.setdefault('data', (ts, status)))
+    gt.render_group_tasks(gt.TaskStatus.COMPLETED)
     ts, status = outputs['data']
     assert status == gt.TaskStatus.COMPLETED
-    assert [t.title for t in ts] == ['B']
+    assert ts == [('G', tasks[1])]

--- a/tests/test_tasks_page_ui.py
+++ b/tests/test_tasks_page_ui.py
@@ -42,7 +42,9 @@ def test_render_my_tasks_page(monkeypatch):
 
 
 def test_render_group_tasks_page(monkeypatch):
-    monkeypatch.setattr(tasks_page, 'render_group_tasks', lambda: None)
+    monkeypatch.setattr(tasks_page, 'render_group_active_tasks', lambda: None)
+    monkeypatch.setattr(tasks_page, 'render_group_completed_tasks', lambda: None)
+    monkeypatch.setattr(tasks_page, 'render_group_deleted_tasks', lambda: None)
     tabs_called.clear()
     tasks_page.render_group_tasks_page()
-    assert tabs_called and tabs_called[0] == ['Group Tasks']
+    assert tabs_called and tabs_called[0] == ['Active Tasks', 'Completed Tasks', 'Deleted Tasks']


### PR DESCRIPTION
## Summary
- add group-level task tab views
- update tasks page to use new group task functions
- revise UI tests for new tabs

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6848522f942c833290d3483c064aea04