### PR TITLE
Implement sortable tasks and detailed view

### DIFF
--- a/src/ui/group_tasks.py
+++ b/src/ui/group_tasks.py
@@ -4,6 +4,7 @@ from src.database.models import Task, TaskStatus
 from src.groups.user_group_service import get_user_group_service
 from src.tasks.task_service import get_task_service
 from src.utils.time_utils import format_user_tz
+from src.utils.sort_utils import sort_group_tasks
 
 
 def _get_group_tasks(status: str) -> List[Tuple[str, Task]]:
@@ -27,6 +28,15 @@ def _render_group_task_list(tasks: List[Tuple[str, Task]], status: str):
         st.info(f'No {status.lower()} tasks found.')
         return
     user_id = st.session_state.user.get('email')
+    if status == TaskStatus.ACTIVE:
+        sort_opts = ['Group', 'Title', 'Due Date']
+    elif status == TaskStatus.COMPLETED:
+        sort_opts = ['Group', 'Title', 'Completed Date']
+    else:
+        sort_opts = ['Group', 'Title', 'Deleted Date']
+    sort_by = st.selectbox('Sort by', sort_opts, key=f'gsort_{status}')
+    descending = st.checkbox('Descending', key=f'gdesc_{status}', value=False)
+    tasks = sort_group_tasks(tasks, sort_by, descending)
     if status == TaskStatus.ACTIVE:
         header = st.columns([2, 3, 1, 2, 1])
         header[0].write('**Group**')
@@ -94,19 +104,13 @@ def _render_group_task_list(tasks: List[Tuple[str, Task]], status: str):
             if task.id in st.session_state.task_details:
                 del st.session_state.task_details[task.id]
             else:
-                st.session_state.task_details[task.id] = True
+                detail = get_task_service().get_task(task.user_id, task.id)
+                st.session_state.task_details[task.id] = detail
             st.rerun()
         if 'task_details' in st.session_state and task.id in st.session_state.task_details:
             with st.expander('Task Details', expanded=True):
-                if task.description:
-                    st.markdown(f'**Description:** {task.description}')
-                if task.notes:
-                    st.markdown(f'**Notes:** {task.notes}')
-                if task.updates and len(task.updates) > 0:
-                    st.subheader('Task History')
-                    for update in sorted(task.updates, key=lambda x: x.get('timestamp'), reverse=True):
-                        ts = format_user_tz(update.get('timestamp'))
-                        st.text(f"{ts}: {update.get('updateText', 'Updated')}")
+                detail = st.session_state.task_details.get(task.id)
+                st.json({k: str(v) for k, v in vars(detail).items()})
         st.markdown("<hr class='task-separator'>", unsafe_allow_html=True)
 
 

--- a/src/utils/sort_utils.py
+++ b/src/utils/sort_utils.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from typing import List, Tuple
+
+from src.database.models import Task
+
+
+def sort_tasks(tasks: List[Task], column: str, descending: bool = False) -> List[Task]:
+    key_map = {
+        'Title': lambda t: (t.title or '').lower(),
+        'Due Date': lambda t: t.due_date or datetime.min,
+        'Completed Date': lambda t: t.completion_date or datetime.min,
+        'Deleted Date': lambda t: t.deletion_date or datetime.min,
+    }
+    key = key_map.get(column, lambda t: t.updated_at or t.created_at or datetime.min)
+    return sorted(tasks, key=key, reverse=descending)
+
+
+def sort_group_tasks(tasks: List[Tuple[str, Task]], column: str, descending: bool = False) -> List[Tuple[str, Task]]:
+    key_map = {
+        'Group': lambda r: (r[0] or '').lower(),
+        'Title': lambda r: (r[1].title or '').lower(),
+        'Due Date': lambda r: r[1].due_date or datetime.min,
+        'Completed Date': lambda r: r[1].completion_date or datetime.min,
+        'Deleted Date': lambda r: r[1].deletion_date or datetime.min,
+    }
+    key = key_map.get(column, lambda r: r[1].updated_at or r[1].created_at or datetime.min)
+    return sorted(tasks, key=key, reverse=descending)

--- a/tests/test_sort_utils.py
+++ b/tests/test_sort_utils.py
@@ -1,0 +1,27 @@
+import sys
+import importlib
+from types import SimpleNamespace
+from datetime import datetime
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root / 'src'))
+
+import src.utils.sort_utils as su
+
+
+def test_sort_tasks():
+    t1 = SimpleNamespace(title='B', due_date=datetime(2024,1,2), completion_date=None, deletion_date=None, updated_at=1, created_at=1)
+    t2 = SimpleNamespace(title='A', due_date=datetime(2024,1,1), completion_date=None, deletion_date=None, updated_at=2, created_at=2)
+    out = su.sort_tasks([t1, t2], 'Title', False)
+    assert out[0] is t2
+    out = su.sort_tasks([t1, t2], 'Due Date', True)
+    assert out[0] is t1
+
+
+def test_sort_group_tasks():
+    t1 = SimpleNamespace(title='B', due_date=None, completion_date=datetime(2024,1,2), deletion_date=None, updated_at=1, created_at=1, user_id='u1')
+    t2 = SimpleNamespace(title='A', due_date=None, completion_date=datetime(2024,1,1), deletion_date=None, updated_at=2, created_at=2, user_id='u2')
+    g = [('G1', t1), ('G2', t2)]
+    out = su.sort_group_tasks(g, 'Group', True)
+    assert out[0][0] == 'G2'

--- a/tests/test_task_details.py
+++ b/tests/test_task_details.py
@@ -1,0 +1,108 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'src'))
+
+st = ModuleType('streamlit')
+class Expander:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+st.expander = lambda *a, **k: Expander()
+class SessionState(dict):
+    def __getattr__(self, name):
+        return self.get(name)
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+st.session_state = SessionState({'user': {'email': 'u'}})
+class Col:
+    def __init__(self):
+        self.is_details = False
+
+    def write(self, *a, **k):
+        pass
+
+    def button(self, *a, **k):
+        return self.is_details
+
+    def columns(self, n):
+        return [Col() for _ in range(n)]
+
+def columns(spec):
+    cols = [Col() for _ in range(len(spec))]
+    if cols:
+        cols[-1].is_details = True
+    return cols
+
+st.columns = columns
+class Container:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+st.container = lambda: Container()
+st.markdown = lambda *a, **k: None
+st.header = lambda *a, **k: None
+st.info = lambda *a, **k: None
+st.selectbox = lambda *a, **k: 'Title'
+st.checkbox = lambda *a, **k: False
+st.json = lambda *a, **k: None
+btn_calls = {}
+
+def button(label, key=None, help=None):
+    if 'details' in key:
+        btn_calls['clicked'] = True
+        return True
+    return False
+st.button = button
+class Col:
+    def __init__(self):
+        self.is_details = False
+
+    def write(self, *a, **k):
+        pass
+
+    def button(self, *a, **k):
+        return self.is_details
+
+    def columns(self, n):
+        return [Col() for _ in range(n)]
+
+def columns(spec):
+    cols = [Col() for _ in range(len(spec))]
+    if cols:
+        cols[-1].is_details = True
+    return cols
+
+st.columns = columns
+st.rerun = lambda: None
+sys.modules['streamlit'] = st
+
+import importlib
+import src.ui.task_list as tl
+importlib.reload(tl)
+
+def test_details_fetch(monkeypatch):
+    task_obj = SimpleNamespace(id='1', title='A', user_id='u', status='active', due_date=None, description='d', notes='n', updates=[])
+    calls = {}
+    def _get(u, i):
+        calls['get'] = (u, i)
+        return task_obj
+
+    service = SimpleNamespace(
+        complete_task=lambda u, i: False,
+        delete_task=lambda u, i: False,
+        restore_task=lambda u, i: False,
+        get_task=_get,
+    )
+    monkeypatch.setattr(tl, 'get_task_service', lambda: service)
+    tl.render_task_list([task_obj], tl.TaskStatus.ACTIVE)
+    assert calls.get('get') == ('u', '1')


### PR DESCRIPTION
## Summary
- add utilities for sorting task records
- allow sorting on all task tabs and group tasks
- fetch full task record when viewing details
- test sorting helpers and details rendering

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6848660f9ba083328ad2f2e38716ddda