### PR TITLE
Add feedback tab for AI Assistant

### DIFF
--- a/src/eval/eval_service.py
+++ b/src/eval/eval_service.py
@@ -21,8 +21,7 @@ class EvalService:
         prompt = self.prompt_repo.get_prompt_by_name_version(prompt_name, version)
         if not prompt:
             raise ValueError(f'Prompt {prompt_name} v{version} not found')
-        tracer = LangChainTracer()
-        chat = ChatOpenAI(api_key=self.api_key, model=self.model, temperature=0, callbacks=[tracer])
+        chat = ChatOpenAI(api_key=self.api_key, model=self.model, temperature=0)
         result_ids = []
         for ev in eval_inputs:
             messages = [SystemMessage(content=prompt.text), HumanMessage(content=ev.input_text)]

--- a/src/ui/ai_chat.py
+++ b/src/ui/ai_chat.py
@@ -1,8 +1,9 @@
-import streamlit as st
+import json
 import logging
+import traceback
+import streamlit as st
 from typing import Dict, Any
 from src.ai.llm_service import get_llm_service, TaskChanges
-import traceback
 from src.database.firestore import get_client
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,68 @@ def __collect_feedback(chat_id: str, resp: TaskChanges) -> bool:
             return True
     return False
 
+def _display_response(resp: TaskChanges):
+    st.subheader('Response')
+    last = st.session_state.get('ai_last_input')
+    if last:
+        st.code(last)
+    st.json(getattr(resp, 'model_dump', resp.dict)(exclude_none=True))
+
+def _process_chat(user_id: str):
+    try:
+        ai_input_with_id = st.session_state.get('ai_input_with_id', f"{st.session_state.ai_input}\n\nuser_id: {user_id}")
+        result = get_llm_service().process_chat(user_id, ai_input_with_id)
+        if result:
+            st.session_state.ai_response = result.get('response')
+            st.session_state.chat_id = result.get('chat_id')
+            st.session_state.ai_input = ''
+            st.session_state.ai_processing = False
+            st.session_state.ai_input_with_id = ''
+            st.rerun()
+    except Exception as e:
+        logger.error(f'Error processing AI chat: {str(e)}')
+        st.error(f'Error processing your question: {str(e)}')
+        st.session_state.ai_processing = False
+        traceback.print_exc()
+
+def _main_tab(user_id: str):
+    if st.session_state.ai_processing:
+        _process_chat(user_id)
+    with st.form(key='ai_chat_form'):
+        ai_input = st.text_area('Your request', value=st.session_state.ai_input, height=100)
+        submit_button = st.form_submit_button('Submit')
+    if submit_button and ai_input.strip():
+        st.session_state.ai_input = ai_input
+        st.session_state.ai_input_with_id = f"{ai_input}\n\nuser_id: {user_id}"
+        st.session_state.ai_last_input = ai_input
+        st.session_state.ai_processing = True
+        st.rerun()
+    if st.session_state.ai_response:
+        _display_response(st.session_state.ai_response)
+
+def _load_chats(user_id: str):
+    return get_client().query('AI_chats', filters=[('user_id', '==', user_id)], order_by='createdAt', direction='DESCENDING', limit=20)
+
+def _feedback_tab(user_id: str):
+    chats = _load_chats(user_id)
+    if not chats:
+        st.info('No chats found.')
+    for chat in chats:
+        text = chat.get('inputText', '').split('user_id')[0].rstrip('\n')
+        st.markdown(f'**{text}**')
+        if st.button('Feedback', key=f"fb_{chat['id']}"):
+            st.session_state.setdefault('fb_open', {})
+            st.session_state.fb_open[chat['id']] = not st.session_state.fb_open.get(chat['id'])
+            st.rerun()
+        if st.session_state.get('fb_open', {}).get(chat['id']):
+            data = chat.get('Response')
+            if data:
+                if isinstance(data, str):
+                    data = json.loads(data)
+                resp = TaskChanges(**data)
+                __collect_feedback(chat['id'], resp)
+        st.divider()
+
 def render_ai_chat():
     st.header('AI Assistant')
     user_id = st.session_state.user.get('email')
@@ -45,32 +108,8 @@ def render_ai_chat():
     if 'ai_processing' not in st.session_state:
         st.session_state.ai_processing = False
     st.markdown('\n    Talk with the AI assistant for help creating and/or updating your tasks. \n    ')
-    if st.session_state.ai_processing:
-        try:
-            ai_input_with_id = st.session_state.get('ai_input_with_id', f'{st.session_state.ai_input}\n\nuser_id: {user_id}')
-            result = get_llm_service().process_chat(user_id, ai_input_with_id)
-            logger.info(f'\n\n\nAI response: {result}')
-            if result:
-                st.session_state.ai_response = result.get('response')
-                st.session_state.chat_id = result.get('chat_id')
-                st.session_state.ai_input = ''
-                st.session_state.ai_processing = False
-                st.session_state.ai_input_with_id = ''
-                st.rerun()
-        except Exception as e:
-            logger.error(f'Error processing AI chat: {str(e)}')
-            st.error(f'Error processing your question: {str(e)}')
-            st.session_state.ai_processing = False
-            traceback.print_exc()
-    with st.form(key='ai_chat_form'):
-        ai_input = st.text_area('Your request', value=st.session_state.ai_input, height=100)
-        submit_button = st.form_submit_button('Submit')
-    if submit_button and ai_input.strip():
-        st.session_state.ai_input = ai_input
-        st.session_state.ai_input_with_id = f'{ai_input}\n\nuser_id: {user_id}'
-        st.session_state.ai_processing = True
-        st.rerun()
-    if st.session_state.ai_response:
-        st.subheader('Response')
-        st.markdown(st.session_state.ai_response)
-        __collect_feedback(st.session_state.chat_id, st.session_state.ai_response)
+    tabs = st.tabs(['Main', 'Feedback'])
+    with tabs[0]:
+        _main_tab(user_id)
+    with tabs[1]:
+        _feedback_tab(user_id)

--- a/tests/test_ai_chat_ui.py
+++ b/tests/test_ai_chat_ui.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'src'))
+
+st = ModuleType('streamlit')
+
+class Tab:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+tabs_called = []
+
+def tabs(names):
+    tabs_called.append(names)
+    return [Tab() for _ in names]
+
+st.tabs = tabs
+st.header = lambda *a, **k: None
+st.markdown = lambda *a, **k: None
+st.form = lambda *a, **k: Tab()
+st.text_area = lambda *a, **k: ''
+st.form_submit_button = lambda *a, **k: False
+
+class SessionState(dict):
+    def __getattr__(self, name):
+        return self.get(name)
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+st.session_state = SessionState({'user': {'email': 'e'}})
+st.code = lambda *a, **k: None
+st.json = lambda *a, **k: None
+st.info = lambda *a, **k: None
+st.button = lambda *a, **k: False
+st.rerun = lambda: None
+sys.modules['streamlit'] = st
+
+import importlib
+import src.ui.ai_chat as ai_chat
+importlib.reload(ai_chat)
+
+
+def test_render_ai_chat_tabs(monkeypatch):
+    monkeypatch.setattr(ai_chat, 'get_client', lambda: SimpleNamespace(query=lambda *a, **k: []))
+    tabs_called.clear()
+    ai_chat.render_ai_chat()
+    assert tabs_called and tabs_called[0] == ['Main', 'Feedback']


### PR DESCRIPTION
## Summary
- split AI assistant interface into Main and Feedback tabs
- display last LLM input with response
- list previous chats and allow feedback on each
- adjust LLM executor and eval service to remove tracing
- add regression tests for AI chat tabs

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68486f754ecc8332a9e74daa2be41863