### PR TITLE
Add Tags support with search

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Streamlit-based task management application with soft-delete functionality and
 - Task management (create, read, update, delete)
 - Soft-delete functionality with task recovery
 - Task categorization (Active, Completed, Deleted)
+- Tag support with search
 - Google OAuth Authentication
 - AI Assistant for task-related queries
 - Firebase Firestore integration

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -13,7 +13,7 @@ class PromptStatus(str, Enum):
 
 class Task:
 
-    def __init__(self, id: Optional[str]=None, user_id: str=None, title: str=None, description: str=None, due_date: Optional[datetime]=None, status: str=TaskStatus.ACTIVE, created_at: Optional[datetime]=None, updated_at: Optional[datetime]=None, completion_date: Optional[datetime]=None, deletion_date: Optional[datetime]=None, notes: str=None, updates: List[Dict[str, Any]]=None, owner_id: Optional[str]=None, owner_email: Optional[str]=None, owner_name: Optional[str]=None):
+    def __init__(self, id: Optional[str]=None, user_id: str=None, title: str=None, description: str=None, due_date: Optional[datetime]=None, status: str=TaskStatus.ACTIVE, created_at: Optional[datetime]=None, updated_at: Optional[datetime]=None, completion_date: Optional[datetime]=None, deletion_date: Optional[datetime]=None, notes: str=None, updates: List[Dict[str, Any]]=None, owner_id: Optional[str]=None, owner_email: Optional[str]=None, owner_name: Optional[str]=None, tags: Optional[List[str]]=None):
         self.id = id
         self.user_id = user_id
         self.title = title
@@ -29,10 +29,11 @@ class Task:
         self.owner_id = owner_id
         self.owner_email = owner_email
         self.owner_name = owner_name
+        self.tags = tags or []
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'Task':
-        return cls(id=data.get('id'), user_id=data.get('userId'), title=data.get('title'), description=data.get('description'), due_date=data.get('dueDate'), status=data.get('status', TaskStatus.ACTIVE), created_at=data.get('createdAt'), updated_at=data.get('updatedAt'), completion_date=data.get('completionDate'), deletion_date=data.get('deletionDate'), notes=data.get('notes'), updates=data.get('updates', []), owner_id=data.get('ownerId'), owner_email=data.get('ownerEmail'), owner_name=data.get('ownerName'))
+        return cls(id=data.get('id'), user_id=data.get('userId'), title=data.get('title'), description=data.get('description'), due_date=data.get('dueDate'), status=data.get('status', TaskStatus.ACTIVE), created_at=data.get('createdAt'), updated_at=data.get('updatedAt'), completion_date=data.get('completionDate'), deletion_date=data.get('deletionDate'), notes=data.get('notes'), updates=data.get('updates', []), owner_id=data.get('ownerId'), owner_email=data.get('ownerEmail'), owner_name=data.get('ownerName'), tags=data.get('tags', []))
 
     def to_dict(self) -> Dict[str, Any]:
         data = {'userId': self.user_id, 'title': self.title, 'status': self.status}
@@ -56,6 +57,8 @@ class Task:
             data['ownerEmail'] = self.owner_email
         if self.owner_name:
             data['ownerName'] = self.owner_name
+        if self.tags:
+            data['tags'] = self.tags
         return data
 
     def validate(self) -> bool:

--- a/src/tasks/task_service.py
+++ b/src/tasks/task_service.py
@@ -37,7 +37,7 @@ class TaskService:
     def create_task(self, user_id: str, task_data: Dict[str, Any]) -> str:
         logger.info(f'Creating task for user {user_id}')
         due_date = task_data.get('due_date') or datetime.now() + timedelta(days=7)
-        task = Task(user_id=user_id, title=task_data.get('title'), description=task_data.get('description'), due_date=due_date, notes=task_data.get('notes'), owner_id=task_data.get('owner_id', user_id), owner_email=task_data.get('owner_email'), owner_name=task_data.get('owner_name'))
+        task = Task(user_id=user_id, title=task_data.get('title'), description=task_data.get('description'), due_date=due_date, notes=task_data.get('notes'), owner_id=task_data.get('owner_id', user_id), owner_email=task_data.get('owner_email'), owner_name=task_data.get('owner_name'), tags=task_data.get('tags'))
         task.updates = [{'timestamp': datetime.now(), 'user': user_id, 'updateText': 'Task created'}]
         return self.repository.create_task(task)
 
@@ -54,6 +54,8 @@ class TaskService:
             db_task_data['notes'] = task_data['notes']
         if 'status' in task_data:
             db_task_data['status'] = task_data['status']
+        if 'tags' in task_data:
+            db_task_data['tags'] = task_data['tags']
         return self.repository.update_task(user_id, task_id, db_task_data)
 
     def delete_task(self, user_id: str, task_id: str) -> bool:

--- a/src/ui/group_tasks.py
+++ b/src/ui/group_tasks.py
@@ -5,6 +5,7 @@ from src.groups.user_group_service import get_user_group_service
 from src.tasks.task_service import get_task_service
 from src.utils.time_utils import format_user_tz
 from src.utils.sort_utils import sort_group_tasks
+from src.utils.filter_utils import filter_tasks_by_tags
 
 
 def _get_group_tasks(status: str) -> List[Tuple[str, Task]]:
@@ -28,6 +29,8 @@ def _render_group_task_list(tasks: List[Tuple[str, Task]], status: str):
         st.info(f'No {status.lower()} tasks found.')
         return
     user_id = st.session_state.user.get('email')
+    tag_query = st.text_input('Search Tags', key=f'gtags_{status}')
+    tasks = filter_tasks_by_tags(tasks, tag_query)
     if status == TaskStatus.ACTIVE:
         sort_opts = ['Group', 'Title', 'Due Date']
     elif status == TaskStatus.COMPLETED:

--- a/src/ui/task_form.py
+++ b/src/ui/task_form.py
@@ -27,6 +27,8 @@ def render_task_form(task: Optional[Task]=None):
                 except ValueError:
                     due_date_value = None
         due_date = st.date_input('Due Date', value=due_date_value if due_date_value else None)
+        tags_str = ', '.join(task.tags) if task and task.tags else ''
+        tags_input = st.text_input('Tags (comma separated)', value=tags_str)
         notes = st.text_area('Notes', value=task.notes if task else '')
         users = get_user_service().get_users()
         opts = {u.get('userName') or u['userEmail']: u['userEmail'] for u in users}
@@ -46,7 +48,8 @@ def render_task_form(task: Optional[Task]=None):
         if due_date and due_date != datetime.today().date():
             due_date_value = datetime.combine(due_date, datetime.min.time())
         user = st.session_state.user
-        task_data = {'title': title, 'description': description if description else None, 'due_date': due_date_value, 'notes': notes if notes else None, 'owner_id': user.get('userId', user.get('email')), 'owner_email': user.get('email'), 'owner_name': user.get('name')}
+        tags = [t.strip() for t in tags_input.split(',') if t.strip()]
+        task_data = {'title': title, 'description': description if description else None, 'due_date': due_date_value, 'notes': notes if notes else None, 'owner_id': user.get('userId', user.get('email')), 'owner_email': user.get('email'), 'owner_name': user.get('name'), 'tags': tags}
         if task:
             if task_service.update_task(user_id, task.id, task_data):
                 st.success('Task updated successfully!')

--- a/src/ui/task_list.py
+++ b/src/ui/task_list.py
@@ -7,6 +7,7 @@ from src.database.models import Task, TaskStatus
 from src.tasks.task_service import get_task_service
 from src.utils.time_utils import format_user_tz
 from src.utils.sort_utils import sort_tasks
+from src.utils.filter_utils import filter_tasks_by_tags
 
 def render_task_list(tasks: List[Task], status: str, on_refresh: Callable=None):
     print(f"\n\n****{status=}\n\n")
@@ -121,6 +122,8 @@ def render_active_tasks():
         st.rerun()
     user_id = st.session_state.user.get('email')
     tasks = get_task_service().get_active_tasks(user_id)
+    tag_query = st.text_input('Search Tags', key='tags_active')
+    tasks = filter_tasks_by_tags(tasks, tag_query)
     st.write(f'Total tasks: {len(tasks)}')
 
     def refresh_tasks():
@@ -132,6 +135,8 @@ def render_completed_tasks():
     st.header('Completed Tasks')
     user_id = st.session_state.user.get('email')
     tasks = get_task_service().get_completed_tasks(user_id)
+    tag_query = st.text_input('Search Tags', key='tags_completed')
+    tasks = filter_tasks_by_tags(tasks, tag_query)
     st.write(f'Total tasks: {len(tasks)}')
 
     def refresh_tasks():
@@ -143,6 +148,8 @@ def render_deleted_tasks():
     st.header('Deleted Tasks')
     user_id = st.session_state.user.get('email')
     tasks = get_task_service().get_deleted_tasks(user_id)
+    tag_query = st.text_input('Search Tags', key='tags_deleted')
+    tasks = filter_tasks_by_tags(tasks, tag_query)
     st.write(f'Total tasks: {len(tasks)}')
 
     def refresh_tasks():

--- a/src/utils/filter_utils.py
+++ b/src/utils/filter_utils.py
@@ -1,0 +1,15 @@
+from typing import Iterable, List, Tuple
+from src.database.models import Task
+
+
+def filter_tasks_by_tags(tasks: Iterable[Task] | Iterable[Tuple[str, Task]], query: str) -> List:
+    tags = [t.strip().lower() for t in query.split(',') if t.strip()]
+    if not tags:
+        return list(tasks)
+    results = []
+    for item in tasks:
+        task = item[1] if isinstance(item, tuple) else item
+        task_tags = [tag.lower() for tag in getattr(task, 'tags', [])]
+        if all(tag in task_tags for tag in tags):
+            results.append(item)
+    return results

--- a/tests/test_filter_utils.py
+++ b/tests/test_filter_utils.py
@@ -1,0 +1,16 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root / 'src'))
+
+from utils.filter_utils import filter_tasks_by_tags
+
+
+def test_filter_tasks_by_tags():
+    t1 = SimpleNamespace(tags=['work', 'urgent'])
+    t2 = SimpleNamespace(tags=['home'])
+    out = filter_tasks_by_tags([t1, t2], 'work')
+    assert out == [t1]
+    out = filter_tasks_by_tags([t1, t2], '')
+    assert out == [t1, t2]

--- a/tests/test_group_tasks_ui.py
+++ b/tests/test_group_tasks_ui.py
@@ -11,6 +11,7 @@ st.header = lambda *a, **k: None
 captured = {}
 st.write = lambda *a, **k: None
 st.info = lambda *a, **k: None
+st.text_input = lambda *a, **k: ''
 
 class SessionState(dict):
     def __getattr__(self, name):

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -13,7 +13,7 @@ def _setup_service(monkeypatch):
 def test_create_task(monkeypatch):
     service, repo = _setup_service(monkeypatch)
     repo.create_task.return_value = 'tid'
-    data = {'title': 'Test', 'description': 'desc', 'notes': 'n', 'due_date': '2024-01-01'}
+    data = {'title': 'Test', 'description': 'desc', 'notes': 'n', 'due_date': '2024-01-01', 'tags': ['a']}
     result = service.create_task('u1', data)
     assert result == 'tid'
     repo.create_task.assert_called_once()
@@ -22,11 +22,12 @@ def test_create_task(monkeypatch):
     assert created.title == 'Test'
     assert created.description == 'desc'
     assert created.notes == 'n'
+    assert created.tags == ['a']
 
 def test_update_task(monkeypatch):
     service, repo = _setup_service(monkeypatch)
-    service.update_task('u1', 't1', {'title': 'new', 'due_date': '2024-01-02'})
-    repo.update_task.assert_called_once_with('u1', 't1', {'title': 'new', 'dueDate': '2024-01-02'})
+    service.update_task('u1', 't1', {'title': 'new', 'due_date': '2024-01-02', 'tags': ['x']})
+    repo.update_task.assert_called_once_with('u1', 't1', {'title': 'new', 'dueDate': '2024-01-02', 'tags': ['x']})
 
 def test_delete_restore_complete(monkeypatch):
     service, repo = _setup_service(monkeypatch)


### PR DESCRIPTION
## Summary
- allow defining tags on a task
- filter tasks by tags in My Tasks and Group Tasks
- provide tag search via UI
- test filtering utility

## Testing
- `pip install -r requirements.txt`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_684879efb43c83328ff186be4ea3d0a4