### PR TITLE
Add AWS Lambda AI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ pull request triggers the workflow defined in
 
 Sample scripts demonstrating Google OAuth and Firestore queries are located in the `examples/` directory. Run them with `streamlit run examples/<script>.py`.
 
+## AWS Lambda APIs
+
+Create a deployment package with dependencies:
+
+```bash
+pip install -r requirements.txt -t lambda_package
+cp -r aws_lambda_api src lambda_package/
+cd lambda_package && zip -r ../lambda-api.zip .
+```
+
+Upload `lambda-api.zip` to AWS Lambda using the Python 3.11 runtime and set the environment variables above. Attach `handler.handler` to paths under `/tasks` and `ai_handler.handler` to the `/chat` path in an API Gateway HTTP API.
+
 
 ## License
 

--- a/aws_lambda_api/ai_handler.py
+++ b/aws_lambda_api/ai_handler.py
@@ -1,0 +1,17 @@
+import json
+from src.ai.llm_service import get_llm_service
+
+def _response(status, body):
+    return {'statusCode': status, 'body': json.dumps(body)}
+
+def handler(event, context):
+    service = get_llm_service()
+    if event.get('httpMethod') == 'POST' and event.get('path') == '/chat':
+        params = event.get('queryStringParameters') or {}
+        user_id = params.get('user_id')
+        data = json.loads(event.get('body') or '{}')
+        text = data.get('text', '')
+        result = service.process_chat(user_id, text)
+        return _response(200, result)
+    return _response(400, {'message': 'bad request'})
+

--- a/aws_lambda_api/handler.py
+++ b/aws_lambda_api/handler.py
@@ -1,0 +1,35 @@
+import json
+from src.tasks.task_service import get_task_service
+
+def _response(status, body):
+    return {'statusCode': status, 'body': json.dumps(body)}
+
+def handler(event, context):
+    service = get_task_service()
+    method = event.get('httpMethod')
+    path = event.get('path', '')
+    params = event.get('queryStringParameters') or {}
+    user_id = params.get('user_id')
+    if path == '/tasks' and method == 'GET':
+        tasks = [t.to_dict() for t in service.get_all_tasks_for_user(user_id)]
+        return _response(200, tasks)
+    if path == '/tasks' and method == 'POST':
+        data = json.loads(event.get('body') or '{}')
+        task_id = service.create_task(user_id, data)
+        return _response(200, {'id': task_id})
+    if path.startswith('/tasks/'):
+        task_id = path.split('/')[-1]
+        if method == 'GET':
+            task = service.get_task(user_id, task_id)
+            if task:
+                return _response(200, task.to_dict())
+            return _response(404, {'message': 'not found'})
+        if method == 'PUT':
+            data = json.loads(event.get('body') or '{}')
+            ok = service.update_task(user_id, task_id, data)
+            return _response(200, {'success': ok})
+        if method == 'DELETE':
+            ok = service.delete_task(user_id, task_id)
+            return _response(200, {'success': ok})
+    return _response(400, {'message': 'bad request'})
+

--- a/tests/test_ai_lambda_handler.py
+++ b/tests/test_ai_lambda_handler.py
@@ -1,0 +1,31 @@
+import sys
+import json
+from pathlib import Path
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'aws_lambda_api'))
+from ai_handler import handler
+
+class DummyService:
+    def __init__(self):
+        self.calls = []
+    def process_chat(self, uid, text):
+        self.calls.append((uid, text))
+        return {'chat_id': 'c', 'response': 'ok'}
+
+def _run(event, monkeypatch, service):
+    monkeypatch.setattr('ai_handler.get_llm_service', lambda: service)
+    return handler(event, None)
+
+def test_chat(monkeypatch):
+    service = DummyService()
+    event = {
+        'httpMethod': 'POST',
+        'path': '/chat',
+        'queryStringParameters': {'user_id': 'u'},
+        'body': json.dumps({'text': 'hi'})
+    }
+    result = _run(event, monkeypatch, service)
+    assert json.loads(result['body']) == {'chat_id': 'c', 'response': 'ok'}
+    assert service.calls == [('u', 'hi')]
+

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,0 +1,62 @@
+import sys
+import json
+from pathlib import Path
+root = Path(__file__).resolve().parents[1]
+sys.path.append(str(root))
+sys.path.append(str(root / 'aws_lambda_api'))
+from handler import handler
+
+class DummyService:
+    def __init__(self):
+        self.calls = []
+    def get_all_tasks_for_user(self, uid):
+        self.calls.append(('list', uid))
+        return [type('T', (), {'to_dict': lambda self: {'id': '1'}})()]
+    def create_task(self, uid, data):
+        self.calls.append(('create', uid, data))
+        return '1'
+    def get_task(self, uid, tid):
+        self.calls.append(('get', uid, tid))
+        return type('T', (), {'to_dict': lambda self: {'id': tid}})()
+    def update_task(self, uid, tid, data):
+        self.calls.append(('update', uid, tid, data))
+        return True
+    def delete_task(self, uid, tid):
+        self.calls.append(('delete', uid, tid))
+        return True
+
+def _run(event, monkeypatch, service):
+    monkeypatch.setattr('handler.get_task_service', lambda: service)
+    return handler(event, None)
+
+def test_list(monkeypatch):
+    service = DummyService()
+    event = {'httpMethod': 'GET', 'path': '/tasks', 'queryStringParameters': {'user_id': 'u'}}
+    result = _run(event, monkeypatch, service)
+    assert json.loads(result['body']) == [{'id': '1'}]
+    assert service.calls == [('list', 'u')]
+
+def test_create(monkeypatch):
+    service = DummyService()
+    event = {
+        'httpMethod': 'POST',
+        'path': '/tasks',
+        'queryStringParameters': {'user_id': 'u'},
+        'body': json.dumps({'title': 't'})
+    }
+    result = _run(event, monkeypatch, service)
+    assert json.loads(result['body']) == {'id': '1'}
+    assert service.calls[0][0] == 'create'
+
+def test_update(monkeypatch):
+    service = DummyService()
+    event = {
+        'httpMethod': 'PUT',
+        'path': '/tasks/x',
+        'queryStringParameters': {'user_id': 'u'},
+        'body': json.dumps({'title': 't'})
+    }
+    result = _run(event, monkeypatch, service)
+    assert json.loads(result['body']) == {'success': True}
+    assert service.calls[0] == ('update', 'u', 'x', {'title': 't'})
+


### PR DESCRIPTION
## Summary
- add AI assistant handler for AWS Lambda
- test lambda AI handler and fix task handler tests
- document using the new Lambda APIs

## Testing
- `pip install -r requirements.txt`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_684c3a097034833293deb27daef24b38